### PR TITLE
Bind coroutine scope to ViewModel lifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation libraries.kotlinCoroutinesCore
     implementation libraries.kotlinStdLib
     implementation libraries.moshi
+    implementation libraries.picasso3
     implementation libraries.retrofit
     implementation libraries.retrofitMoshi
     implementation libraries.retrofitKotlinCoroutines

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     debugImplementation libraries.chuck
     releaseImplementation libraries.chuckNoOp
     implementation libraries.dagger
-    kapt libraries.daggerAndroid
-    kapt libraries.daggerCompiler
+    implementation libraries.kotlinCoroutinesAndroid
+    implementation libraries.kotlinCoroutinesCore
     implementation libraries.kotlinStdLib
     implementation libraries.moshi
     implementation libraries.retrofit
@@ -40,6 +40,9 @@ dependencies {
     implementation libraries.supportDesign
     implementation libraries.supportRecyclerView
     implementation libraries.supportV13
+
+    kapt libraries.daggerAndroid
+    kapt libraries.daggerCompiler
 
     // Android runner and rules support
     androidTestImplementation(libraries.androidTestRunner) {

--- a/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
@@ -1,14 +1,11 @@
 package com.ataulm.artcollector.paintings
 
-import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.ViewModelProviders
 import com.ataulm.artcollector.AddApiKeyQueryParameterInterceptor
 import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.paintings.data.AndroidPaintingsRepository
-import com.ataulm.artcollector.paintings.domain.Painting
 import com.ataulm.artcollector.paintings.domain.PaintingsRepository
 import com.ataulm.artcollector.paintings.ui.PaintingsActivity
-import com.ataulm.artcollector.paintings.ui.PaintingsLiveData
 import com.ataulm.artcollector.paintings.ui.PaintingsViewModel
 import com.ataulm.artcollector.paintings.ui.PaintingsViewModelFactory
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
@@ -19,7 +16,6 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
-
 @Module
 internal object PaintingsModule {
 
@@ -27,12 +23,6 @@ internal object PaintingsModule {
     @Provides
     fun paintingsRepository(paintingsRepository: AndroidPaintingsRepository): PaintingsRepository {
         return paintingsRepository
-    }
-
-    @JvmStatic
-    @Provides
-    fun paintingsLiveData(paintingsLiveData: PaintingsLiveData): LiveData<List<Painting>> {
-        return paintingsLiveData
     }
 
     @JvmStatic

--- a/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
@@ -42,15 +42,11 @@ internal object PaintingsModule {
 
     @JvmStatic
     @Provides
-    fun chuckInterceptor(activity: PaintingsActivity) = ChuckInterceptor(activity)
-
-    @JvmStatic
-    @Provides
-    fun harvardArtMuseumApi(chuckInterceptor: ChuckInterceptor): HarvardArtMuseumApi {
+    fun harvardArtMuseumApi(activity: PaintingsActivity): HarvardArtMuseumApi {
         return Retrofit.Builder()
                 .client(OkHttpClient.Builder()
                         .addNetworkInterceptor(AddApiKeyQueryParameterInterceptor("get an api key")) // TODO: pass this via buildconfig
-                        .addInterceptor(chuckInterceptor)
+                        .addInterceptor(ChuckInterceptor(activity))
                         .build())
                 .baseUrl(HarvardArtMuseumApi.ENDPOINT)
                 .addCallAdapterFactory(CoroutineCallAdapterFactory())

--- a/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/PaintingsModule.kt
@@ -10,6 +10,7 @@ import com.ataulm.artcollector.paintings.ui.PaintingsViewModel
 import com.ataulm.artcollector.paintings.ui.PaintingsViewModelFactory
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.readystatesoftware.chuck.ChuckInterceptor
+import com.squareup.picasso.Picasso
 import dagger.Module
 import dagger.Provides
 import okhttp3.OkHttpClient
@@ -29,6 +30,10 @@ internal object PaintingsModule {
     @Provides
     fun viewModel(activity: PaintingsActivity, viewModelFactory: PaintingsViewModelFactory) =
             ViewModelProviders.of(activity, viewModelFactory).get(PaintingsViewModel::class.java)
+
+    @JvmStatic
+    @Provides
+    fun picasso(activity: PaintingsActivity) = Picasso.Builder(activity).build()
 
     @JvmStatic
     @Provides

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsActivity.kt
@@ -3,10 +3,12 @@ package com.ataulm.artcollector.paintings.ui
 import android.arch.lifecycle.Observer
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import android.util.Log
+import android.support.v7.widget.GridLayoutManager
 import com.ataulm.artcollector.R
 import com.ataulm.artcollector.paintings.domain.Painting
 import com.ataulm.artcollector.paintings.injectDependencies
+import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.activity_paintings.*
 import javax.inject.Inject
 
 class PaintingsActivity : AppCompatActivity() {
@@ -14,13 +16,22 @@ class PaintingsActivity : AppCompatActivity() {
     @Inject
     internal lateinit var viewModel: PaintingsViewModel
 
+    @Inject
+    internal lateinit var picasso: Picasso
+
     override fun onCreate(savedInstanceState: Bundle?) {
         injectDependencies()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_paintings)
 
-        viewModel.paintings.observe(this, Observer<List<Painting>> { t ->
-            Log.d("!!!", t.toString())
+        val paintingsAdapter = PaintingsAdapter(picasso)
+        recyclerView.apply {
+            adapter = paintingsAdapter
+            layoutManager = GridLayoutManager(this@PaintingsActivity, 2)
+        }
+
+        viewModel.paintings.observe(this, Observer<List<Painting>> { paintings ->
+            paintings?.let { paintingsAdapter.submitList(it) }
         })
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
@@ -1,0 +1,36 @@
+package com.ataulm.artcollector.paintings.ui
+
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.ataulm.artcollector.R
+import com.ataulm.artcollector.paintings.domain.Painting
+import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.itemview_painting.view.*
+
+internal class PaintingsAdapter constructor(
+        private val picasso: Picasso
+) : ListAdapter<Painting, PaintingsAdapter.PaintingViewHolder>(PaintingDiffer) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
+        return PaintingViewHolder(picasso, view)
+    }
+
+    override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
+
+    object PaintingDiffer : DiffUtil.ItemCallback<Painting>() {
+        override fun areItemsTheSame(oldItem: Painting, newItem: Painting) = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Painting, newItem: Painting) = oldItem == newItem
+    }
+
+    internal class PaintingViewHolder(private val picasso: Picasso, view: View) : RecyclerView.ViewHolder(view) {
+
+        fun bind(item: Painting) {
+            picasso.load(item.imageUrl).into(itemView.itemviewPaintingImageView)
+        }
+    }
+}

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
@@ -30,7 +30,7 @@ internal class PaintingsAdapter constructor(
     internal class PaintingViewHolder(private val picasso: Picasso, view: View) : RecyclerView.ViewHolder(view) {
 
         fun bind(item: Painting) {
-            picasso.load(item.imageUrl).into(itemView.itemviewPaintingImageView)
+            picasso.load(item.imageUrl).into(itemView.imageView)
         }
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
@@ -22,9 +22,7 @@ internal class PaintingsLiveData @Inject constructor(
         super.onActive()
         job = CoroutineScope(Dispatchers.IO).launch {
             val paintings = getPaintings()
-            withContext(Dispatchers.Default) {
-                postValue(paintings) // TODO: what's the Dispatcher for main thread so I can use setValue?
-            }
+            withContext(Dispatchers.Main) { value = paintings }
         }
     }
 

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
@@ -5,29 +5,32 @@ import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import com.ataulm.artcollector.paintings.domain.GetPaintingsUseCase
 import com.ataulm.artcollector.paintings.domain.Painting
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 internal class PaintingsViewModel @Inject constructor(
-        val paintings: LiveData<List<Painting>>
-) : ViewModel()
-
-internal class PaintingsLiveData @Inject constructor(
         private val getPaintings: GetPaintingsUseCase
-) : MutableLiveData<List<Painting>>() {
+) : ViewModel() {
 
-    private var job: Job? = null
+    private val _paintings = MutableLiveData<List<Painting>>()
+    val paintings: LiveData<List<Painting>> = _paintings
 
-    override fun onActive() {
-        super.onActive()
-        job = CoroutineScope(Dispatchers.IO).launch {
+    private val parentJob = Job()
+    private val coroutineScope = CoroutineScope(parentJob)
+
+    init {
+        coroutineScope.launch(Dispatchers.IO) {
             val paintings = getPaintings()
-            withContext(Dispatchers.Main) { value = paintings }
+            withContext(Dispatchers.Main) { _paintings.value = paintings }
         }
     }
 
-    override fun onInactive() {
-        super.onInactive()
-        job?.cancel()
+    override fun onCleared() {
+        super.onCleared()
+        parentJob.cancel()
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModelFactory.kt
+++ b/app/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModelFactory.kt
@@ -1,16 +1,15 @@
 package com.ataulm.artcollector.paintings.ui
 
-import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
-import com.ataulm.artcollector.paintings.domain.Painting
+import com.ataulm.artcollector.paintings.domain.GetPaintingsUseCase
 import javax.inject.Inject
 
 internal class PaintingsViewModelFactory @Inject constructor(
-        private val paintingsLiveData: LiveData<List<Painting>>
+        private val paintingsUseCase: GetPaintingsUseCase
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>) =
-            PaintingsViewModel(paintingsLiveData) as T
+            PaintingsViewModel(paintingsUseCase) as T
 }

--- a/app/src/main/res/layout/activity_paintings.xml
+++ b/app/src/main/res/layout/activity_paintings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
-
-</LinearLayout>
+<android.support.v7.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recyclerView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/itemview_painting.xml
+++ b/app/src/main/res/layout/itemview_painting.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="250dp">
+
+    <ImageView
+        android:id="@+id/itemviewPaintingImageView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:importantForAccessibility="no"
+        android:scaleType="centerCrop" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/itemview_painting.xml
+++ b/app/src/main/res/layout/itemview_painting.xml
@@ -4,7 +4,7 @@
     android:layout_height="250dp">
 
     <ImageView
-        android:id="@+id/itemviewPaintingImageView"
+        android:id="@+id/imageView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:importantForAccessibility="no"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-  <string name="app_name">example</string>
+  <string name="app_name">art collector</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -20,5 +20,8 @@ allprojects {
         maven {
             url 'https://dl.bintray.com/kotlin/kotlin-eap/'
         }
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,15 +1,16 @@
 ext {
     versions = [
-            androidSdk : [
+            androidSdk      : [
                     compile: 28,
                     min    : 23,
                     target : 28
             ],
-            chuck      : '1.1.0',
-            dagger     : '2.16',
-            kotlin     : '1.3.0-rc-57',
-            supportTest: '1.0.2',
-            support    : '28.0.0-alpha3'
+            chuck           : '1.1.0',
+            dagger          : '2.16',
+            kotlin          : '1.3.0-rc-146',
+            kotlinCoroutines: '1.0.0-RC1',
+            supportTest     : '1.0.2',
+            support         : '28.0.0-alpha3'
     ]
 
     libraries = [
@@ -29,6 +30,8 @@ ext {
             googleTruth                   : 'com.google.truth:truth:0.42',
             jUnit                         : 'junit:junit:4.12',
             kotlinStdLib                  : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}",
+            kotlinCoroutinesAndroid       : "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}",
+            kotlinCoroutinesCore          : "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}",
             mockitoCore                   : 'org.mockito:mockito-core:2.19.1',
             mockitoKotlin                 : 'com.nhaarman:mockito-kotlin-kt1.1:1.5.0',
             moshi                         : 'com.squareup.retrofit2:converter-moshi:2.4.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,6 +37,7 @@ ext {
             mockitoKotlin                 : 'com.nhaarman:mockito-kotlin-kt1.1:1.5.0',
             moshi                         : "com.squareup.moshi:moshi:${versions.moshi}",
             moshiKotlinCodegen            : "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
+            picasso3                      : 'com.squareup.picasso:picasso:3.0.0-SNAPSHOT',
             retrofit                      : 'com.squareup.retrofit2:retrofit:2.4.0',
             retrofitKotlinCoroutines      : 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2',
             retrofitMoshi                 : 'com.squareup.retrofit2:converter-moshi:2.4.0',


### PR DESCRIPTION
- a new scope was being created every time the livedata switched from inactive to active which was wasteful - we only need one and if no coroutines are running in it, that's ok
- the viewmodel now creates this once per instance
- the viewmodel will request the list of paintings on init
- displays images

![image](https://user-images.githubusercontent.com/2678555/48127705-4432e700-e239-11e8-9ec2-76d011323244.png)
