### PR TITLE
Add `painting` as a dynamic feature module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
                     'proguard-rules-retrofit.pro'
         }
     }
-    dynamicFeatures = [':paintings', ":painting"]
+    dynamicFeatures = [':paintings', ':painting']
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,9 @@ android {
                     'proguard-rules-retrofit.pro'
         }
     }
-    dynamicFeatures = [':paintings']
+    dynamicFeatures = [':paintings', ":painting"]
+
+
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,6 @@ android {
         }
     }
     dynamicFeatures = [':paintings', ":painting"]
-
-
 }
 
 dependencies {

--- a/app/src/main/java/com/ataulm/artcollector/DataObserver.kt
+++ b/app/src/main/java/com/ataulm/artcollector/DataObserver.kt
@@ -1,0 +1,13 @@
+package com.ataulm.artcollector
+
+import android.arch.lifecycle.Observer
+
+class DataObserver<T>(private val handleData: (T) -> Unit) : Observer<T> {
+
+    override fun onChanged(data: T?) {
+        if (data == null) {
+            throw IllegalArgumentException("data should never be null")
+        }
+        handleData(data)
+    }
+}

--- a/app/src/main/java/com/ataulm/artcollector/EventObserver.kt
+++ b/app/src/main/java/com/ataulm/artcollector/EventObserver.kt
@@ -1,0 +1,22 @@
+package com.ataulm.artcollector
+
+import android.arch.lifecycle.Observer
+
+class EventObserver<T>(private val handleEvent: (T) -> Unit) : Observer<Event<T>> {
+
+    override fun onChanged(event: Event<T>?) {
+        event?.value()?.let { handleEvent(it) }
+    }
+}
+
+class Event<T>(private val value: T) {
+
+    private var delivered = false
+
+    fun value() = if (delivered) {
+        null
+    } else {
+        delivered = true
+        value
+    }
+}

--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -13,7 +13,7 @@ interface HarvardArtMuseumApi {
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_&$INC_FIELDS")
     fun paintings(): Deferred<ApiPaintingsResponse>
 
-    @GET("object/{object_id}")
+    @GET("object/{object_id}?$INC_FIELDS")
     fun painting(@Path("object_id") id: String): Deferred<ApiRecord>
 
     companion object {
@@ -57,7 +57,7 @@ data class ApiRecord(
         @Json(name = "id") val id: Int,
         @Json(name = "title") val title: String,
         @Json(name = "description") val description: String?,
-        @Json(name = "primaryimageurl") val primaryImageUrl: String,
+        @Json(name = "primaryimageurl") val primaryImageUrl: String?,
         @Json(name = "people") val people: List<ApiPerson>
 )
 

--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -6,11 +6,15 @@ import kotlinx.coroutines.Deferred
 import okhttp3.Interceptor
 import okhttp3.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface HarvardArtMuseumApi {
 
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_&$INC_FIELDS")
-    fun paintings(): Deferred<ApiResponse>
+    fun paintings(): Deferred<ApiPaintingsResponse>
+
+    @GET("object/{object_id}")
+    fun painting(@Path("object_id") id: String): Deferred<ApiRecord>
 
     companion object {
 
@@ -34,7 +38,7 @@ internal class AddApiKeyQueryParameterInterceptor(private val apiKey: String) : 
 }
 
 @JsonClass(generateAdapter = true)
-data class ApiResponse(
+data class ApiPaintingsResponse(
         @Json(name = "info") val info: ApiInfo,
         @Json(name = "records") val records: List<ApiRecord>
 )

--- a/app/src/main/java/com/ataulm/artcollector/Navigation.kt
+++ b/app/src/main/java/com/ataulm/artcollector/Navigation.kt
@@ -1,6 +1,7 @@
 package com.ataulm.artcollector
 
 import android.content.Intent
+import android.net.Uri
 
 enum class Navigation(private val semiQualifiedActivityName: String) {
 
@@ -8,9 +9,13 @@ enum class Navigation(private val semiQualifiedActivityName: String) {
     PAINTINGS("paintings.ui.PaintingsActivity");
 
     fun viewIntent(artistId: String, paintingId: String): Intent {
-        return viewIntent()
-                .putExtra("artistId", artistId)
-                .putExtra("paintingId", paintingId)
+        val uri = Uri.Builder()
+                .scheme("https://")
+                .authority("art-collector.ataulm.com")
+                .path("$artistId/$paintingId")
+                .build()
+
+        return viewIntent().setData(uri)
     }
 
     fun viewIntent(): Intent {

--- a/app/src/main/java/com/ataulm/artcollector/Navigation.kt
+++ b/app/src/main/java/com/ataulm/artcollector/Navigation.kt
@@ -1,0 +1,21 @@
+package com.ataulm.artcollector
+
+import android.content.Intent
+
+enum class Navigation(private val semiQualifiedActivityName: String) {
+
+    PAINTING("painting.ui.PaintingActivity"),
+    PAINTINGS("paintings.ui.PaintingsActivity");
+
+    fun viewIntent(artistId: String, paintingId: String): Intent {
+        return viewIntent()
+                .putExtra("artistId", artistId)
+                .putExtra("paintingId", paintingId)
+    }
+
+    fun viewIntent(): Intent {
+        val componentName = "${BuildConfig.APPLICATION_ID}.$semiQualifiedActivityName"
+        return Intent(Intent.ACTION_VIEW)
+                .setClassName(BuildConfig.APPLICATION_ID, componentName)
+    }
+}

--- a/app/src/main/java/com/ataulm/artcollector/TemporaryHomeActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/TemporaryHomeActivity.kt
@@ -1,6 +1,5 @@
 package com.ataulm.artcollector
 
-import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 
@@ -13,16 +12,5 @@ class TemporaryHomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         startActivity(Navigation.PAINTINGS.viewIntent())
-    }
-}
-
-enum class Navigation(private val semiQualifiedActivityName: String) {
-
-    PAINTINGS("paintings.ui.PaintingsActivity");
-
-    fun viewIntent(): Intent {
-        val componentName = "${BuildConfig.APPLICATION_ID}.$semiQualifiedActivityName"
-        return Intent(Intent.ACTION_VIEW)
-                .setClassName(BuildConfig.APPLICATION_ID, componentName)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
     <string name="app_name">art collector</string>
-    <string name="title_painting">Module Title</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">art collector</string>
+    <string name="title_painting">Module Title</string>
 </resources>

--- a/painting/build.gradle
+++ b/painting/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'com.android.dynamic-feature'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
+
+android {
+    compileSdkVersion versions.androidSdk.compile
+}
+
+dependencies {
+    implementation project(':app')
+
+    kapt libraries.daggerCompiler
+}

--- a/painting/src/main/AndroidManifest.xml
+++ b/painting/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
+    package="com.ataulm.artcollector.painting">
+
+    <dist:module
+        dist:onDemand="false"
+        dist:title="@string/title_painting">
+        <dist:fusing dist:include="true" />
+    </dist:module>
+
+    <application>
+        <activity android:name=".ui.PaintingActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+

--- a/painting/src/main/java/com/ataulm/artcollector/painting/PaintingComponent.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/PaintingComponent.kt
@@ -1,0 +1,37 @@
+package com.ataulm.artcollector.painting
+
+import com.ataulm.artcollector.ApplicationComponent
+import com.ataulm.artcollector.ArtCollectorApplication
+import com.ataulm.artcollector.painting.domain.PaintingId
+import com.ataulm.artcollector.painting.ui.PaintingActivity
+import dagger.BindsInstance
+import dagger.Component
+
+@Component(modules = [PaintingModule::class], dependencies = [ApplicationComponent::class])
+internal interface PaintingComponent {
+
+    fun inject(activity: PaintingActivity)
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun activity(activity: PaintingActivity): Builder
+
+        fun withParent(component: ApplicationComponent): Builder
+
+        @BindsInstance
+        fun with(paintingId: PaintingId): Builder
+
+        fun build(): PaintingComponent
+    }
+}
+
+internal fun PaintingActivity.injectDependencies(paintingId: PaintingId) {
+    DaggerPaintingComponent.builder()
+            .withParent(ArtCollectorApplication.component(this))
+            .with(paintingId)
+            .activity(this)
+            .build()
+            .inject(this)
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/PaintingModule.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/PaintingModule.kt
@@ -1,0 +1,25 @@
+package com.ataulm.artcollector.painting
+
+import android.arch.lifecycle.ViewModelProviders
+import com.ataulm.artcollector.painting.data.AndroidPaintingRepository
+import com.ataulm.artcollector.painting.domain.PaintingRepository
+import com.ataulm.artcollector.painting.ui.PaintingActivity
+import com.ataulm.artcollector.painting.ui.PaintingViewModel
+import com.ataulm.artcollector.painting.ui.PaintingViewModelFactory
+import dagger.Module
+import dagger.Provides
+
+@Module
+internal object PaintingModule {
+
+    @JvmStatic
+    @Provides
+    fun paintingRepository(paintingRepository: AndroidPaintingRepository): PaintingRepository {
+        return paintingRepository
+    }
+
+    @JvmStatic
+    @Provides
+    fun viewModel(activity: PaintingActivity, viewModelFactory: PaintingViewModelFactory) =
+            ViewModelProviders.of(activity, viewModelFactory).get(PaintingViewModel::class.java)
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
@@ -1,0 +1,30 @@
+package com.ataulm.artcollector.painting.data
+
+import com.ataulm.artcollector.ApiRecord
+import com.ataulm.artcollector.HarvardArtMuseumApi
+import com.ataulm.artcollector.painting.domain.Artist
+import com.ataulm.artcollector.painting.domain.Painting
+import com.ataulm.artcollector.painting.domain.PaintingId
+import com.ataulm.artcollector.painting.domain.PaintingRepository
+import javax.inject.Inject
+
+internal class AndroidPaintingRepository @Inject constructor(
+        private val harvardArtMuseumApi: HarvardArtMuseumApi,
+        private val paintingId: PaintingId
+) : PaintingRepository {
+
+    override suspend fun painting(): Painting {
+        return harvardArtMuseumApi.painting(paintingId.value).await().toPainting()
+    }
+
+    private fun ApiRecord.toPainting(): Painting {
+        val apiPerson = people.first()
+        return Painting(
+                id.toString(),
+                title,
+                description,
+                primaryImageUrl,
+                Artist(apiPerson.personId.toString(), apiPerson.name)
+        )
+    }
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/GetPaintingUseCase.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/GetPaintingUseCase.kt
@@ -1,0 +1,10 @@
+package com.ataulm.artcollector.painting.domain
+
+import javax.inject.Inject
+
+internal class GetPaintingUseCase @Inject constructor(
+        private val repository: PaintingRepository
+) {
+
+    suspend operator fun invoke() = repository.painting()
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/Painting.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/Painting.kt
@@ -4,7 +4,7 @@ internal data class Painting(
         val id: String,
         val title: String,
         val description: String?,
-        val imageUrl: String,
+        val imageUrl: String?, // nullable because https://github.com/harvardartmuseums/api-docs/issues/6
         val artist: Artist
 )
 

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/Painting.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/Painting.kt
@@ -1,0 +1,13 @@
+package com.ataulm.artcollector.painting.domain
+
+internal data class Painting(
+        val id: String,
+        val title: String,
+        val description: String?,
+        val imageUrl: String,
+        val artist: Artist
+)
+
+internal data class PaintingId(val value: String)
+
+internal data class Artist(val id: String, val name: String)

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
@@ -1,0 +1,6 @@
+package com.ataulm.artcollector.painting.domain
+
+internal interface PaintingRepository {
+
+    suspend fun painting(): Painting
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -1,0 +1,35 @@
+package com.ataulm.artcollector.painting.ui
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.ataulm.artcollector.DataObserver
+import com.ataulm.artcollector.EventObserver
+import com.ataulm.artcollector.Navigation
+import com.ataulm.artcollector.painting.R
+import com.ataulm.artcollector.painting.domain.Painting
+import com.ataulm.artcollector.painting.domain.PaintingId
+import com.ataulm.artcollector.painting.injectDependencies
+import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.activity_painting.*
+import javax.inject.Inject
+
+class PaintingActivity : AppCompatActivity() {
+
+    @Inject
+    internal lateinit var viewModel: PaintingViewModel
+
+    @Inject
+    internal lateinit var picasso: Picasso
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_painting)
+
+        val objectId = "143495" // TODO: get the objectid from the intent
+        injectDependencies(PaintingId(objectId))
+
+        viewModel.painting.observe(this, DataObserver<Painting> { painting ->
+            picasso.load(painting.imageUrl).into(imageView)
+        })
+    }
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -3,8 +3,6 @@ package com.ataulm.artcollector.painting.ui
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import com.ataulm.artcollector.DataObserver
-import com.ataulm.artcollector.EventObserver
-import com.ataulm.artcollector.Navigation
 import com.ataulm.artcollector.painting.R
 import com.ataulm.artcollector.painting.domain.Painting
 import com.ataulm.artcollector.painting.domain.PaintingId
@@ -25,7 +23,9 @@ class PaintingActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_painting)
 
-        val objectId = "143495" // TODO: get the objectid from the intent
+        val uri = intent.data!!
+        val objectId = uri.pathSegments.last()
+
         injectDependencies(PaintingId(objectId))
 
         viewModel.painting.observe(this, DataObserver<Painting> { painting ->

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
@@ -16,8 +16,8 @@ internal class PaintingViewModel @Inject constructor(
         private val getPainting: GetPaintingUseCase
 ) : ViewModel() {
 
-    private val _paintings = MutableLiveData<Painting>()
-    val painting: LiveData<Painting> = _paintings
+    private val _painting = MutableLiveData<Painting>()
+    val painting: LiveData<Painting> = _painting
 
     private val parentJob = Job()
     private val coroutineScope = CoroutineScope(parentJob)
@@ -25,7 +25,7 @@ internal class PaintingViewModel @Inject constructor(
     init {
         coroutineScope.launch(Dispatchers.IO) {
             val paintings = getPainting()
-            withContext(Dispatchers.Main) { _paintings.value = paintings }
+            withContext(Dispatchers.Main) { _painting.value = paintings }
         }
     }
 

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
@@ -1,0 +1,36 @@
+package com.ataulm.artcollector.painting.ui
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import com.ataulm.artcollector.painting.domain.GetPaintingUseCase
+import com.ataulm.artcollector.painting.domain.Painting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class PaintingViewModel @Inject constructor(
+        private val getPainting: GetPaintingUseCase
+) : ViewModel() {
+
+    private val _paintings = MutableLiveData<Painting>()
+    val painting: LiveData<Painting> = _paintings
+
+    private val parentJob = Job()
+    private val coroutineScope = CoroutineScope(parentJob)
+
+    init {
+        coroutineScope.launch(Dispatchers.IO) {
+            val paintings = getPainting()
+            withContext(Dispatchers.Main) { _paintings.value = paintings }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        parentJob.cancel()
+    }
+}

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModelFactory.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.ataulm.artcollector.painting.ui
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import com.ataulm.artcollector.painting.domain.GetPaintingUseCase
+import javax.inject.Inject
+
+internal class PaintingViewModelFactory @Inject constructor(
+        private val paintingUseCase: GetPaintingUseCase
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>) =
+            PaintingViewModel(paintingUseCase) as T
+}

--- a/painting/src/main/res/layout/activity_painting.xml
+++ b/painting/src/main/res/layout/activity_painting.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/imageView"
+    android:importantForAccessibility="no"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:scaleType="centerCrop" />

--- a/painting/src/main/res/values/strings.xml
+++ b/painting/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="title_painting">Painting</string>
+</resources>

--- a/paintings/src/main/java/com/ataulm/artcollector/paintings/domain/Painting.kt
+++ b/paintings/src/main/java/com/ataulm/artcollector/paintings/domain/Painting.kt
@@ -4,7 +4,7 @@ internal data class Painting(
         val id: String,
         val title: String,
         val description: String?,
-        val imageUrl: String,
+        val imageUrl: String?, // nullable because https://github.com/harvardartmuseums/api-docs/issues/6
         val artist: Artist
 )
 

--- a/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsActivity.kt
+++ b/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsActivity.kt
@@ -4,6 +4,9 @@ import android.arch.lifecycle.Observer
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
+import com.ataulm.artcollector.DataObserver
+import com.ataulm.artcollector.EventObserver
+import com.ataulm.artcollector.Navigation
 import com.ataulm.artcollector.paintings.R
 import com.ataulm.artcollector.paintings.domain.Painting
 import com.ataulm.artcollector.paintings.injectDependencies
@@ -24,14 +27,19 @@ class PaintingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_paintings)
 
-        val paintingsAdapter = PaintingsAdapter(picasso)
+        val paintingsAdapter = PaintingsAdapter(picasso) { viewModel.onClick(it) }
         recyclerView.apply {
             adapter = paintingsAdapter
             layoutManager = GridLayoutManager(this@PaintingsActivity, 2)
         }
 
-        viewModel.paintings.observe(this, Observer<List<Painting>> { paintings ->
-            paintings?.let { paintingsAdapter.submitList(it) }
+        viewModel.paintings.observe(this, DataObserver<List<Painting>> { paintings ->
+            paintingsAdapter.submitList(paintings)
+        })
+
+        viewModel.events.observe(this, EventObserver {
+            val painting = it.painting
+            startActivity(Navigation.PAINTING.viewIntent(painting.artist.id, painting.id))
         })
     }
 }

--- a/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
+++ b/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsAdapter.kt
@@ -12,12 +12,13 @@ import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.itemview_painting.view.*
 
 internal class PaintingsAdapter constructor(
-        private val picasso: Picasso
+        private val picasso: Picasso,
+        private val onClick: (Painting) -> Unit
 ) : ListAdapter<Painting, PaintingsAdapter.PaintingViewHolder>(PaintingDiffer) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
-        return PaintingViewHolder(picasso, view)
+        return PaintingViewHolder(picasso, onClick, view)
     }
 
     override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
@@ -27,9 +28,14 @@ internal class PaintingsAdapter constructor(
         override fun areContentsTheSame(oldItem: Painting, newItem: Painting) = oldItem == newItem
     }
 
-    internal class PaintingViewHolder(private val picasso: Picasso, view: View) : RecyclerView.ViewHolder(view) {
+    internal class PaintingViewHolder(
+            private val picasso: Picasso,
+            private val onClick: (Painting) -> Unit,
+            view: View
+    ) : RecyclerView.ViewHolder(view) {
 
         fun bind(item: Painting) {
+            itemView.setOnClickListener { onClick(item) }
             itemView.artistTextView.text = item.artist.name
             picasso.load(item.imageUrl).into(itemView.imageView)
         }

--- a/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
+++ b/paintings/src/main/java/com/ataulm/artcollector/paintings/ui/PaintingsViewModel.kt
@@ -3,6 +3,7 @@ package com.ataulm.artcollector.paintings.ui
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
+import com.ataulm.artcollector.Event
 import com.ataulm.artcollector.paintings.domain.GetPaintingsUseCase
 import com.ataulm.artcollector.paintings.domain.Painting
 import kotlinx.coroutines.CoroutineScope
@@ -19,6 +20,10 @@ internal class PaintingsViewModel @Inject constructor(
     private val _paintings = MutableLiveData<List<Painting>>()
     val paintings: LiveData<List<Painting>> = _paintings
 
+    private val _events = MutableLiveData<Event<NavigateToPainting>>()
+    val events: LiveData<Event<NavigateToPainting>>
+        get() = _events
+
     private val parentJob = Job()
     private val coroutineScope = CoroutineScope(parentJob)
 
@@ -29,8 +34,14 @@ internal class PaintingsViewModel @Inject constructor(
         }
     }
 
+    fun onClick(painting: Painting) {
+        _events.value = Event(NavigateToPainting(painting))
+    }
+
     override fun onCleared() {
         super.onCleared()
         parentJob.cancel()
     }
 }
+
+internal data class NavigateToPainting(val painting: Painting)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':app'
-include ':paintings'
+include ':painting'
+include ':paintings' // TODO: this one should be consumed by `app`


### PR DESCRIPTION
This follows from https://github.com/ataulm/art-collector/pull/4 where I added a dynamic feature module and a dummy activity. In that PR, I should not have extracted a dynamic feature module for that one because it should have remained as part of the base apk - the base feature requires a default activity (the gallery activity).

![painting](https://user-images.githubusercontent.com/2678555/48295517-58493500-e441-11e8-8579-543382f7d8a7.gif)

This PR adds a new feature module to be able to see a single painting. Again, this is a required module for now - clicking on a painting from the PaintingsActivity will create an intent which is coupled directly with the one in this new feature - ideally, it'd be firing ACTION_VIEW with the web url for that image: `https://art-collector.ataulm.com/<artist-id>/<painting-id>` but I don't have support for App Links yet.

I said I'd remove the temporary activity in this one but I'll do it in the next PR to make the addition of a dynamic feature module very explicit in one PR.

There's also a bug it seems in the API, where the image url is coming back as null when it definitely exists (it's included in the response on the previous screen). In this case, it'll just load a blank page.