### PR TITLE
Set title for each screen

### DIFF
--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -14,11 +14,14 @@ interface HarvardArtMuseumApi {
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_&$INC_FIELDS")
     fun gallery(): Deferred<ApiPaintingsResponse>
 
+    @GET("person")
+    fun artist(@Query("q") qValue: String): Deferred<ApiPersonResponse>
+
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$INC_FIELDS")
     fun artistGallery(@Query("person") artistId: String): Deferred<ApiPaintingsResponse>
 
     @GET("object/{object_id}?$INC_FIELDS")
-    fun painting(@Path("object_id") id: String): Deferred<ApiRecord>
+    fun painting(@Path("object_id") id: String): Deferred<ApiObjectRecord>
 
     companion object {
 
@@ -44,7 +47,13 @@ internal class AddApiKeyQueryParameterInterceptor(private val apiKey: String) : 
 @JsonClass(generateAdapter = true)
 data class ApiPaintingsResponse(
         @Json(name = "info") val info: ApiInfo,
-        @Json(name = "records") val records: List<ApiRecord>
+        @Json(name = "records") val records: List<ApiObjectRecord>
+)
+
+@JsonClass(generateAdapter = true)
+data class ApiPersonResponse(
+        @Json(name = "info") val info: ApiInfo,
+        @Json(name = "records") val records: List<ApiPersonRecord>
 )
 
 @JsonClass(generateAdapter = true)
@@ -57,7 +66,13 @@ data class ApiInfo(
 )
 
 @JsonClass(generateAdapter = true)
-data class ApiRecord(
+data class ApiPersonRecord(
+        @Json(name = "personid") val personId: Int,
+        @Json(name = "displayname") val displayName: String
+)
+
+@JsonClass(generateAdapter = true)
+data class ApiObjectRecord(
         @Json(name = "id") val id: Int,
         @Json(name = "title") val title: String,
         @Json(name = "description") val description: String?,

--- a/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
@@ -1,6 +1,6 @@
 package com.ataulm.artcollector.gallery.data
 
-import com.ataulm.artcollector.ApiRecord
+import com.ataulm.artcollector.ApiObjectRecord
 import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.gallery.domain.Artist
 import com.ataulm.artcollector.gallery.domain.Gallery
@@ -18,7 +18,7 @@ internal class AndroidGalleryRepository @Inject constructor(
         return Gallery(paintings)
     }
 
-    private fun ApiRecord.toPainting(): Painting {
+    private fun ApiObjectRecord.toPainting(): Painting {
         val apiPerson = people.first()
         return Painting(
                 id.toString(),

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
@@ -2,5 +2,7 @@ package com.ataulm.artcollector.artist.domain
 
 internal interface ArtistRepository {
 
+    suspend fun artist(): Artist
+
     suspend fun artistGallery(): Gallery
 }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/GetArtistUseCase.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/GetArtistUseCase.kt
@@ -1,0 +1,10 @@
+package com.ataulm.artcollector.artist.domain
+
+import javax.inject.Inject
+
+internal class GetArtistUseCase @Inject constructor(
+        private val repository: ArtistRepository
+) {
+
+    suspend operator fun invoke() = repository.artist()
+}

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/Models.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/Models.kt
@@ -10,6 +10,9 @@ internal data class Painting(
         val artist: Artist
 )
 
-internal data class Artist(val id: String, val name: String)
+internal data class Artist(
+        val id: String,
+        val name: String
+)
 
 internal data class ArtistId(val value: String)

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistActivity.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistActivity.kt
@@ -33,8 +33,9 @@ class ArtistActivity : AppCompatActivity() {
         recyclerView.adapter = adapter
         recyclerView.layoutManager = GridLayoutManager(this@ArtistActivity, 2)
 
-        viewModel.gallery.observe(this, DataObserver<Gallery> { gallery ->
-            adapter.submitList(gallery)
+        viewModel.artistGallery.observe(this, DataObserver<ArtistGallery> { artistGallery ->
+            title = artistGallery.artist.name
+            adapter.submitList(artistGallery.gallery)
         })
 
         viewModel.events.observe(this, EventObserver {

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModelFactory.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModelFactory.kt
@@ -3,13 +3,15 @@ package com.ataulm.artcollector.artist.ui
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import com.ataulm.artcollector.artist.domain.GetArtistGalleryUseCase
+import com.ataulm.artcollector.artist.domain.GetArtistUseCase
 import javax.inject.Inject
 
 internal class ArtistViewModelFactory @Inject constructor(
+        private val artistUseCase: GetArtistUseCase,
         private val artistGalleryUseCase: GetArtistGalleryUseCase
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>) =
-            ArtistViewModel(artistGalleryUseCase) as T
+            ArtistViewModel(artistUseCase, artistGalleryUseCase) as T
 }

--- a/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
@@ -1,6 +1,6 @@
 package com.ataulm.artcollector.painting.data
 
-import com.ataulm.artcollector.ApiRecord
+import com.ataulm.artcollector.ApiObjectRecord
 import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.painting.domain.Artist
 import com.ataulm.artcollector.painting.domain.Painting
@@ -17,7 +17,7 @@ internal class AndroidPaintingRepository @Inject constructor(
         return harvardArtMuseumApi.painting(paintingId.value).await().toPainting()
     }
 
-    private fun ApiRecord.toPainting(): Painting {
+    private fun ApiObjectRecord.toPainting(): Painting {
         val apiPerson = people.first()
         return Painting(
                 id.toString(),

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -27,6 +27,7 @@ class PaintingActivity : AppCompatActivity() {
         injectDependencies(PaintingId(paintingId))
 
         viewModel.painting.observe(this, DataObserver<Painting> { painting ->
+            title = painting.title
             picasso.load(painting.imageUrl).into(imageView)
         })
     }


### PR DESCRIPTION
It's difficult to distinguish the three distinct areas in the app: gallery, artist gallery and painting.

This PR adds the setting of the title:

- gallery: app title remains
- artist gallery: the artist name is used
- painting: the title of the painting

![titles](https://user-images.githubusercontent.com/2678555/48305016-71e98b80-e4d8-11e8-80cb-c4e674bc8af7.gif)

It's a bit janky, since it waits for the response before it loads the title. There's a few ways to mitigate this perception of jankiness:

- pass the artist name/painting name (which we have when the user clicks) as intent extras so there's no need to wait for the API
- avoid setting any title (i.e. hide app name) until the response comes back and fade it in when it does

I think a combination of the two makes sense:

- avoid setting any title
- if we have intent extras, use these, but they're not mandatory (won't be available when we use AppLinks)