### PR TITLE
Adds Deep Link support for the three screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ art collector displays a selection of paintings from the [Harvard Art Museum API
 We need three screens:
 
 - `/` showing a collection of paintings
-- `/artist/{person_id}` showing the collection of paintings by the given artist
-- `/artist/{person_id}/{object_id}` showing a single painting
+- `/{person_id}` showing the collection of paintings by the given artist
+- `/{person_id}/{object_id}` showing a single painting
 
 ## Why
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,19 @@
 
         </activity-alias>
 
+        <activity android:name=".DeepLinkActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="art-collector.ataulm.com" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ataulm/artcollector/DeepLinkActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/DeepLinkActivity.kt
@@ -1,0 +1,32 @@
+package com.ataulm.artcollector
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+
+private const val ARTIST = 0
+private const val PAINTING = 1
+
+/**
+ * Supports http/https:
+ *
+ * - art-collector.ataulm.com
+ * - art-collector.ataulm.com/{artist-id}
+ * - art-collector.ataulm.com/{artist-id}/{painting-id}
+ */
+class DeepLinkActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val uri = getIntentUri()
+        val segments = uri.pathSegments
+        val intent = when (uri.pathSegments.size) {
+            2 -> paintingIntent(segments[ARTIST], segments[PAINTING])
+            1 -> artistGalleryIntent(segments[ARTIST])
+            else -> galleryIntent()
+        }
+        startActivity(intent)
+        finish()
+    }
+
+    private fun getIntentUri() = intent.data!! // only way to open this activity
+}

--- a/app/src/main/java/com/ataulm/artcollector/Navigation.kt
+++ b/app/src/main/java/com/ataulm/artcollector/Navigation.kt
@@ -5,8 +5,11 @@ import android.net.Uri
 
 private const val SCHEME = "https"
 private const val AUTHORITY = "art-collector.ataulm.com"
+private const val GALLERY = "${BuildConfig.APPLICATION_ID}.gallery.ui.GalleryActivity"
 private const val ARTIST_GALLERY = "${BuildConfig.APPLICATION_ID}.artist.ui.ArtistActivity"
 private const val PAINTING = "${BuildConfig.APPLICATION_ID}.painting.ui.PaintingActivity"
+
+fun galleryIntent() = intent(GALLERY)
 
 fun artistGalleryIntent(artistId: String): Intent {
     val uri = Uri.Builder()
@@ -15,7 +18,7 @@ fun artistGalleryIntent(artistId: String): Intent {
             .path(artistId)
             .build()
 
-    return intent(uri, ARTIST_GALLERY)
+    return intent(ARTIST_GALLERY, uri)
 }
 
 fun paintingIntent(artistId: String, paintingId: String): Intent {
@@ -25,10 +28,10 @@ fun paintingIntent(artistId: String, paintingId: String): Intent {
             .path("$artistId/$paintingId")
             .build()
 
-    return intent(uri, PAINTING)
+    return intent(PAINTING, uri)
 }
 
-private fun intent(uri: Uri, componentName: String): Intent {
+private fun intent(componentName: String, uri: Uri? = null): Intent {
     return Intent(Intent.ACTION_VIEW)
             .setClassName(BuildConfig.APPLICATION_ID, componentName)
             .setData(uri)


### PR DESCRIPTION
Since the URLs I want to support are `foo.com`, `foo.com/{id}`, `foo.com/{id}/{id2}` (each for a different screen), I don't think it's doable by providing intent filters for each Activity 🤔 (happy to be shown how though).

![deeplink](https://user-images.githubusercontent.com/2678555/48309453-2d3d0f00-e52f-11e8-9216-247852cda5a9.gif)

I added a single activity to handle the deeplinks where I can have more control over the logic that parses the URIs and decides where to navigate.

---

This means that I can't get rid of the component names in the base module so there'll always be an implicit dependency **on** feature modules 😞 