### PR TITLE
Request only objects with images that have no copyright issues

### DIFF
--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -28,7 +28,7 @@ interface HarvardArtMuseumApi {
         const val ENDPOINT = "https://api.harvardartmuseums.org"
         private const val PAINTINGS_ = "classification=26"
         private const val WITH_IMAGES_ = "hasimage=1"
-        private const val WITH_ARTIST_ = "q=people.role:Artist"
+        private const val WITH_ARTIST_ = "q=people.role:Artist AND imagepermissionlevel:0"
         private const val INC_FIELDS = "fields=id,title,description,primaryimageurl,people,url,creditline"
     }
 }
@@ -78,7 +78,7 @@ data class ApiObjectRecord(
         @Json(name = "description") val description: String?,
         @Json(name = "url") val url: String,
         @Json(name = "creditline") val creditLine: String?,
-        @Json(name = "primaryimageurl") val primaryImageUrl: String?,
+        @Json(name = "primaryimageurl") val primaryImageUrl: String,
         @Json(name = "people") val people: List<ApiPerson>
 )
 

--- a/app/src/main/java/com/ataulm/artcollector/gallery/domain/Models.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/domain/Models.kt
@@ -6,7 +6,7 @@ internal data class Painting(
         val id: String,
         val title: String,
         val description: String?,
-        val imageUrl: String?, // nullable because https://github.com/harvardartmuseums/api-docs/issues/6
+        val imageUrl: String,
         val artist: Artist
 )
 

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/Models.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/Models.kt
@@ -6,7 +6,7 @@ internal data class Painting(
         val id: String,
         val title: String,
         val description: String?,
-        val imageUrl: String?, // nullable because https://github.com/harvardartmuseums/api-docs/issues/6
+        val imageUrl: String,
         val artist: Artist
 )
 

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/Models.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/Models.kt
@@ -6,7 +6,7 @@ internal data class Painting(
         val webUrl: String,
         val description: String?,
         val creditLine: String?,
-        val imageUrl: String?, // nullable because https://github.com/harvardartmuseums/api-docs/issues/6
+        val imageUrl: String,
         val artist: Artist
 )
 

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -69,13 +69,11 @@ class PaintingActivity : AppCompatActivity() {
     }
 
     private fun Painting.loadImageIfDifferent() {
-        if (imageUrl != null) {
-            paintingImageViewTarget?.request?.clear()
-            paintingImageViewTarget = glideRequestManager
-                    .load(imageUrl)
-                    .listener(startTransitionRequestListener)
-                    .into(imageView)
-        }
+        paintingImageViewTarget?.request?.clear()
+        paintingImageViewTarget = glideRequestManager
+                .load(imageUrl)
+                .listener(startTransitionRequestListener)
+                .into(imageView)
     }
 
     private val startTransitionRequestListener = object : RequestListener<Drawable> {


### PR DESCRIPTION
The `painting` property was nullable because of a bug in the API. This has been resolved, but actually, it means that we should never have had access to these images in the first place.

This PR modifies the request so that we only request objects for which we have access to the images.

https://github.com/harvardartmuseums/api-docs/issues/6#issuecomment-442618209