### PR TITLE
Check URL is different before re-loading

### DIFF
--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -28,8 +28,6 @@ class PaintingActivity : AppCompatActivity() {
     @Inject
     internal lateinit var glideRequestManager: RequestManager
 
-    private var paintingImageViewTarget: Target<Drawable>? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_painting)
@@ -61,19 +59,19 @@ class PaintingActivity : AppCompatActivity() {
 
     private fun Intent.loadImageIfAvailable() {
         imageUrl()?.let {
-            paintingImageViewTarget = glideRequestManager
-                    .load(it)
+            glideRequestManager.load(it)
                     .listener(startTransitionRequestListener)
                     .into(imageView)
         }
     }
 
     private fun Painting.loadImageIfDifferent() {
-        paintingImageViewTarget?.request?.clear()
-        paintingImageViewTarget = glideRequestManager
-                .load(imageUrl)
-                .listener(startTransitionRequestListener)
-                .into(imageView)
+        if (imageUrl != intent.imageUrl()) {
+            glideRequestManager.clear(imageView)
+            glideRequestManager.load(imageUrl)
+                    .listener(startTransitionRequestListener)
+                    .into(imageView)
+        }
     }
 
     private val startTransitionRequestListener = object : RequestListener<Drawable> {


### PR DESCRIPTION
Started noticing flashing. `loadImageIfDifferent` doesn't check if the images are different before attempting a load.

I must have removed the check accidentally at one point. This PR adds it back.

---

Also simplifies the cancel load - don't need to keep a reference to the target.