### PR TITLE
Avoid overlay for shared element transition to fix overlap with nav bar

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -2,9 +2,12 @@
 
     <style name="ArtCollector" parent="Theme.AppCompat.Light">
         <item name="android:windowBackground">@android:color/white</item>
+        <item name="android:windowSharedElementsUseOverlay">false</item>
     </style>
 
-    <style name="ArtCollector.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar"/>
+    <style name="ArtCollector.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowSharedElementsUseOverlay">false</item>
+    </style>
 
     <style name="ArtCollector.Painting" parent="ArtCollector.NoActionBar">
         <item name="android:windowBackground">@android:color/black</item>


### PR DESCRIPTION
before (overlaps nav) | after
---|---
![before](https://user-images.githubusercontent.com/2678555/49684288-f58f9b80-fac9-11e8-997f-572ae601e127.gif) | ![after](https://user-images.githubusercontent.com/2678555/49684287-f58f9b80-fac9-11e8-937a-2d04a504bbc5.gif)
