### PR TITLE
Map Gallery to UiGallery in gallery module

### DIFF
--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
@@ -10,7 +10,6 @@ import com.ataulm.artcollector.DataObserver
 import com.ataulm.artcollector.EventObserver
 import com.ataulm.artcollector.R
 import com.ataulm.artcollector.artistGalleryIntent
-import com.ataulm.artcollector.domain.Gallery
 import com.ataulm.artcollector.gallery.injectDependencies
 import com.ataulm.artcollector.paintingIntent
 import com.bumptech.glide.RequestManager
@@ -39,7 +38,7 @@ class GalleryActivity : AppCompatActivity() {
         recyclerView.adapter = adapter
         recyclerView.addItemDecoration(GallerySpacingItemDecoration(resources))
 
-        viewModel.gallery.observe(this, DataObserver<Gallery> { gallery ->
+        viewModel.gallery.observe(this, DataObserver<UiGallery> { gallery ->
             adapter.submitList(gallery)
         })
 

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
@@ -6,12 +6,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.util.Pair
 import androidx.recyclerview.widget.RecyclerView
-import com.ataulm.artcollector.DataObserver
-import com.ataulm.artcollector.EventObserver
-import com.ataulm.artcollector.R
-import com.ataulm.artcollector.artistGalleryIntent
+import com.ataulm.artcollector.*
 import com.ataulm.artcollector.gallery.injectDependencies
-import com.ataulm.artcollector.paintingIntent
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.activity_gallery.*
 import kotlinx.android.synthetic.main.itemview_painting.view.*
@@ -55,13 +51,13 @@ class GalleryActivity : AppCompatActivity() {
     private val onClickPainting: (Int) -> Unit = { viewModel.onClick(it) }
 
     private fun navigateToArtistGallery(it: NavigateToArtistGallery) {
-        val intent = artistGalleryIntent(it.artist.id)
+        val intent = artistGalleryIntent(it.artistId)
         startActivity(intent)
     }
 
     private fun navigateToPainting(command: NavigateToPainting) {
         val (painting, adapterPosition) = command.painting to command.adapterPosition
-        val paintingIntent = paintingIntent(painting.artist.id, painting.id, painting.imageUrl)
+        val paintingIntent = paintingIntent(painting.artistId, painting.id, painting.imageUrl)
         val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, recyclerView.sharedElements(adapterPosition))
         startActivity(paintingIntent, options.toBundle())
     }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
@@ -7,7 +7,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ataulm.artcollector.R
-import com.ataulm.artcollector.domain.Painting
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.itemview_painting.view.*
 
@@ -15,7 +14,7 @@ internal class GalleryAdapter constructor(
         private val glideRequestManager: RequestManager,
         private val onClick: (Int) -> Unit,
         private val onClickArtist: (Int) -> Unit
-) : ListAdapter<Painting, GalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
+) : ListAdapter<UiPainting, GalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
@@ -24,9 +23,9 @@ internal class GalleryAdapter constructor(
 
     override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
 
-    object PaintingDiffer : DiffUtil.ItemCallback<Painting>() {
-        override fun areItemsTheSame(oldItem: Painting, newItem: Painting) = oldItem.id == newItem.id
-        override fun areContentsTheSame(oldItem: Painting, newItem: Painting) = oldItem == newItem
+    object PaintingDiffer : DiffUtil.ItemCallback<UiPainting>() {
+        override fun areItemsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem == newItem
     }
 
     internal class PaintingViewHolder(
@@ -36,9 +35,9 @@ internal class GalleryAdapter constructor(
             view: View
     ) : RecyclerView.ViewHolder(view) {
 
-        fun bind(item: Painting) {
+        fun bind(item: UiPainting) {
             itemView.setOnClickListener { onClick(adapterPosition) }
-            itemView.artistTextView.text = item.artist.name
+            itemView.artistTextView.text = item.artistName
             itemView.artistTextView.setOnClickListener { onClickArtist(adapterPosition) }
             glideRequestManager
                     .load(item.imageUrl)

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
@@ -2,36 +2,18 @@ package com.ataulm.artcollector.gallery.ui
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import com.ataulm.artcollector.Event
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Gallery
 import com.ataulm.artcollector.gallery.domain.GetGalleryUseCase
-import com.ataulm.artcollector.domain.Painting
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import javax.inject.Inject
 
 internal class GalleryViewModel @Inject constructor(
         private val getGallery: GetGalleryUseCase
 ) : ViewModel() {
 
-    private val _gallery = MutableLiveData<Gallery>()
-    val gallery: LiveData<UiGallery> = Transformations.map(_gallery) { gallery ->
-        val paintingUis = gallery.map { painting ->
-            UiPainting(
-                    painting.id,
-                    painting.title,
-                    painting.imageUrl,
-                    painting.artist.name
-            )
-        }
-        UiGallery(paintingUis)
-    }
+    private val _gallery = MutableLiveData<UiGallery>()
+    val gallery: LiveData<UiGallery> = _gallery
 
     private val _events = MutableLiveData<Event<NavigateCommand>>()
     val events: LiveData<Event<NavigateCommand>>
@@ -43,7 +25,17 @@ internal class GalleryViewModel @Inject constructor(
     init {
         coroutineScope.launch(Dispatchers.IO) {
             val gallery = getGallery()
-            withContext(Dispatchers.Main) { _gallery.value = gallery }
+            val paintingUis = gallery.map { painting ->
+                UiPainting(
+                        painting.id,
+                        painting.title,
+                        painting.imageUrl,
+                        painting.artist.id,
+                        painting.artist.name
+                )
+            }
+            val uiGallery = UiGallery(paintingUis)
+            withContext(Dispatchers.Main) { _gallery.value = uiGallery }
         }
     }
 
@@ -53,7 +45,7 @@ internal class GalleryViewModel @Inject constructor(
     }
 
     fun onClickArtist(adapterPosition: Int) {
-        val artist = _gallery.value!![adapterPosition].artist
+        val artist = _gallery.value!![adapterPosition].artistId
         _events.value = Event(NavigateToArtistGallery(artist))
     }
 
@@ -64,5 +56,5 @@ internal class GalleryViewModel @Inject constructor(
 }
 
 internal sealed class NavigateCommand
-internal data class NavigateToPainting(val painting: Painting, val adapterPosition: Int) : NavigateCommand()
-internal data class NavigateToArtistGallery(val artist: Artist) : NavigateCommand()
+internal data class NavigateToPainting(val painting: UiPainting, val adapterPosition: Int) : NavigateCommand()
+internal data class NavigateToArtistGallery(val artistId: String) : NavigateCommand()

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
@@ -2,6 +2,7 @@ package com.ataulm.artcollector.gallery.ui
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import com.ataulm.artcollector.Event
 import com.ataulm.artcollector.domain.Artist
@@ -20,7 +21,17 @@ internal class GalleryViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _gallery = MutableLiveData<Gallery>()
-    val gallery: LiveData<Gallery> = _gallery
+    val gallery: LiveData<UiGallery> = Transformations.map(_gallery) { gallery ->
+        val paintingUis = gallery.map { painting ->
+            UiPainting(
+                    painting.id,
+                    painting.title,
+                    painting.imageUrl,
+                    painting.artist.name
+            )
+        }
+        UiGallery(paintingUis)
+    }
 
     private val _events = MutableLiveData<Event<NavigateCommand>>()
     val events: LiveData<Event<NavigateCommand>>

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiGallery.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiGallery.kt
@@ -1,0 +1,3 @@
+package com.ataulm.artcollector.gallery.ui
+
+internal class UiGallery(collection: Collection<UiPainting>) : ArrayList<UiPainting>(collection)

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
@@ -4,5 +4,6 @@ internal data class UiPainting(
         val id: String,
         val title: String,
         val imageUrl: String,
+        val artistId: String,
         val artistName: String
 )

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
@@ -1,0 +1,8 @@
+package com.ataulm.artcollector.gallery.ui
+
+internal data class UiPainting(
+        val id: String,
+        val title: String,
+        val imageUrl: String,
+        val artistName: String
+)


### PR DESCRIPTION
A continuation of #30 (unify domain models) - here, we define some UI models.

Notes:

#### the ViewModel is mapping from domain to UI

Since the `GetGalleryUseCase` is part of the domain, the use case doesn't know about the UI Model. The ViewModel's responsibility is to provide state for the View to observe. 

It could be argued that the View (activity) should do the mapping - I'm less fussed. The benefit of this way is that we'll be able to add unit tests for the ViewModel to ensure that the correct UI model is generated (I haven't though 😋).

I think it's important that the mapping does not exist in the use case or anywhere else in that direction (e.g. a repository whose interface would also be part of the domain).

#### the UI models are `internal`

Unlike the domain models which are shared across our app in implementation, I decided to make the UI models `internal` since they'll depend on the UI.

It might be that several modules require widgets that look the same and require the same UI model. Since this project is really small, I'm happier with duplicating in those cases for now and revisiting the decision if necessary.

#### the entire collection is mapped for every update

This happens on the background thread, so it's part of the "loading" and the result is delivered on the main thread.

Still though, with really large datasets, many allocations can result in a lot of memory churn, leading to a lot of garbage collection which can lead to skipped frames.

What if, instead, we didn't have to do it to the whole dataset, and we could do it to only the subset that we're viewing at the time? Like... paging...