### PR TITLE
Add Paging3 Library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ android {
 }
 
 dependencies {
+    api project(':domain')
     api libraries.androidxAppCompat
     api libraries.androidxConstraintLayout
     api libraries.androidxLegacySupportV13

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,11 @@ buildProperties {
 }
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     compileSdkVersion versions.androidSdk.compile
 
     defaultConfig {
@@ -66,12 +71,12 @@ dependencies {
     api libraries.kotlinStdLib
     api libraries.photoView
 
+    implementation libraries.androidxPagingRuntime
     debugImplementation libraries.chuck
     releaseImplementation libraries.chuckNoOp
     implementation libraries.moshi
     implementation libraries.retrofit
     implementation libraries.retrofitMoshi
-    implementation libraries.retrofitKotlinCoroutines
 
     kapt libraries.daggerAndroid
     kapt libraries.daggerCompiler

--- a/app/src/main/java/com/ataulm/artcollector/ApplicationComponent.kt
+++ b/app/src/main/java/com/ataulm/artcollector/ApplicationComponent.kt
@@ -2,7 +2,6 @@ package com.ataulm.artcollector
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.readystatesoftware.chuck.ChuckInterceptor
 import dagger.BindsInstance
 import dagger.Component
@@ -45,7 +44,6 @@ object ApplicationModule {
                         .addInterceptor(ChuckInterceptor(application))
                         .build())
                 .baseUrl(HarvardArtMuseumApi.ENDPOINT)
-                .addCallAdapterFactory(CoroutineCallAdapterFactory())
                 .addConverterFactory(MoshiConverterFactory.create())
                 .build()
                 .create(HarvardArtMuseumApi::class.java)

--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -11,22 +11,24 @@ import retrofit2.http.Query
 
 interface HarvardArtMuseumApi {
 
-    @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_AND_ACCESS_TO_IMAGES_&$PAGE_SIZE_&$INC_FIELDS")
-    fun gallery(): Deferred<ApiPaintingsResponse>
+    @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_AND_ACCESS_TO_IMAGES_&$INC_FIELDS")
+    suspend fun gallery(
+            @Query("size") pageSize: Int = 100,
+            @Query("page") page: Int? = null
+    ): ApiPaintingsResponse
 
     @GET("person")
-    fun artist(@Query("q") qValue: String): Deferred<ApiPersonResponse>
+    suspend fun artist(@Query("q") qValue: String): ApiPersonResponse
 
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$INC_FIELDS")
-    fun artistGallery(@Query("person") artistId: String): Deferred<ApiPaintingsResponse>
+    suspend fun artistGallery(@Query("person") artistId: String): ApiPaintingsResponse
 
     @GET("object/{object_id}?$INC_FIELDS")
-    fun painting(@Path("object_id") id: String): Deferred<ApiObjectRecord>
+    suspend fun painting(@Path("object_id") id: String): ApiObjectRecord
 
     companion object {
 
         const val ENDPOINT = "https://api.harvardartmuseums.org"
-        private const val PAGE_SIZE_ = "size=100"
         private const val PAINTINGS_ = "classification=26"
         private const val WITH_IMAGES_ = "hasimage=1"
         private const val WITH_ARTIST_AND_ACCESS_TO_IMAGES_ = "q=people.role:Artist AND imagepermissionlevel:0"
@@ -62,8 +64,7 @@ data class ApiInfo(
         @Json(name = "totalrecordsperquery") val totalRecordsPerQuery: Int,
         @Json(name = "totalrecords") val totalRecords: Int,
         @Json(name = "pages") val pages: Int,
-        @Json(name = "page") val page: Int,
-        @Json(name = "next") val next: String?
+        @Json(name = "page") val page: Int
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
+++ b/app/src/main/java/com/ataulm/artcollector/HarvardArtMuseumApi.kt
@@ -13,7 +13,7 @@ interface HarvardArtMuseumApi {
 
     @GET("object?$PAINTINGS_&$WITH_IMAGES_&$WITH_ARTIST_AND_ACCESS_TO_IMAGES_&$INC_FIELDS")
     suspend fun gallery(
-            @Query("size") pageSize: Int = 100,
+            @Query("size") pageSize: Int,
             @Query("page") page: Int? = null
     ): ApiPaintingsResponse
 

--- a/app/src/main/java/com/ataulm/artcollector/gallery/GalleryModule.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/GalleryModule.kt
@@ -1,8 +1,8 @@
 package com.ataulm.artcollector.gallery
 
 import androidx.lifecycle.ViewModelProviders
+import com.ataulm.artcollector.datanotdomain.GalleryRepository
 import com.ataulm.artcollector.gallery.data.AndroidGalleryRepository
-import com.ataulm.artcollector.gallery.domain.GalleryRepository
 import com.ataulm.artcollector.gallery.ui.GalleryActivity
 import com.ataulm.artcollector.gallery.ui.GalleryViewModel
 import com.ataulm.artcollector.gallery.ui.GalleryViewModelFactory

--- a/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
@@ -2,10 +2,10 @@ package com.ataulm.artcollector.gallery.data
 
 import com.ataulm.artcollector.ApiObjectRecord
 import com.ataulm.artcollector.HarvardArtMuseumApi
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Painting
-import com.ataulm.artcollector.domain.Gallery
-import com.ataulm.artcollector.gallery.domain.GalleryRepository
+import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.Painting
+import com.ataulm.artcollector.Gallery
+import com.ataulm.artcollector.datanotdomain.GalleryRepository
 import javax.inject.Inject
 
 internal class AndroidGalleryRepository @Inject constructor(

--- a/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/data/AndroidGalleryRepository.kt
@@ -2,10 +2,9 @@ package com.ataulm.artcollector.gallery.data
 
 import androidx.paging.PagingSource
 import com.ataulm.artcollector.ApiObjectRecord
-import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.Painting
-import com.ataulm.artcollector.Gallery
 import com.ataulm.artcollector.datanotdomain.GalleryRepository
 import javax.inject.Inject
 
@@ -13,28 +12,9 @@ internal class AndroidGalleryRepository @Inject constructor(
         private val harvardArtMuseumApi: HarvardArtMuseumApi
 ) : GalleryRepository {
 
-    override suspend fun gallery(): Gallery {
-        val paintings = harvardArtMuseumApi.gallery().records
-                .map { it.toPainting() }
-        return Gallery(paintings)
-    }
-
-    override fun pagedGallery(): PagingSource<Int, Painting> {
+    override fun gallery(): PagingSource<Int, Painting> {
         return GalleryPagingSource(harvardArtMuseumApi)
     }
-}
-
-private fun ApiObjectRecord.toPainting(): Painting {
-    val apiPerson = people.first()
-    return Painting(
-            id.toString(),
-            title,
-            url,
-            description,
-            creditLine,
-            primaryImageUrl,
-            Artist(apiPerson.personId.toString(), apiPerson.name)
-    )
 }
 
 private class GalleryPagingSource(private val harvardArtMuseumApi: HarvardArtMuseumApi)
@@ -47,6 +27,19 @@ private class GalleryPagingSource(private val harvardArtMuseumApi: HarvardArtMus
                 data = result.records.map { it.toPainting() },
                 prevKey = if (result.info.page == 1) null else result.info.page - 1,
                 nextKey = if (result.info.page == result.info.pages) null else result.info.page + 1
+        )
+    }
+
+    private fun ApiObjectRecord.toPainting(): Painting {
+        val apiPerson = people.first()
+        return Painting(
+                id.toString(),
+                title,
+                url,
+                description,
+                creditLine,
+                primaryImageUrl,
+                Artist(apiPerson.personId.toString(), apiPerson.name)
         )
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/domain/GalleryRepository.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/domain/GalleryRepository.kt
@@ -1,8 +1,0 @@
-package com.ataulm.artcollector.gallery.domain
-
-import com.ataulm.artcollector.domain.Gallery
-
-internal interface GalleryRepository {
-
-    suspend fun gallery(): Gallery
-}

--- a/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
@@ -7,12 +7,5 @@ internal class GetGalleryUseCase @Inject constructor(
         private val repository: GalleryRepository
 ) {
 
-    suspend operator fun invoke() = repository.gallery()
-}
-
-internal class GetPagedGalleryUseCase @Inject constructor(
-        private val repository: GalleryRepository
-) {
-
-    operator fun invoke() = repository.pagedGallery()
+    operator fun invoke() = repository.gallery()
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
@@ -1,5 +1,6 @@
 package com.ataulm.artcollector.gallery.domain
 
+import com.ataulm.artcollector.datanotdomain.GalleryRepository
 import javax.inject.Inject
 
 internal class GetGalleryUseCase @Inject constructor(
@@ -8,4 +9,3 @@ internal class GetGalleryUseCase @Inject constructor(
 
     suspend operator fun invoke() = repository.gallery()
 }
-

--- a/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/domain/GetGalleryUseCase.kt
@@ -9,3 +9,10 @@ internal class GetGalleryUseCase @Inject constructor(
 
     suspend operator fun invoke() = repository.gallery()
 }
+
+internal class GetPagedGalleryUseCase @Inject constructor(
+        private val repository: GalleryRepository
+) {
+
+    operator fun invoke() = repository.pagedGallery()
+}

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
@@ -1,22 +1,17 @@
 package com.ataulm.artcollector.gallery.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.util.Pair
 import androidx.lifecycle.lifecycleScope
-import androidx.paging.PagingDataAdapter
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView
-import androidx.viewpager.widget.PagerAdapter
-import com.ataulm.artcollector.*
+import com.ataulm.artcollector.EventObserver
+import com.ataulm.artcollector.R
+import com.ataulm.artcollector.artistGalleryIntent
 import com.ataulm.artcollector.gallery.injectDependencies
+import com.ataulm.artcollector.paintingIntent
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.activity_gallery.*
-import kotlinx.android.synthetic.main.itemview_painting.view.*
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,17 +29,12 @@ class GalleryActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_gallery)
 
-//        val adapter = GalleryAdapter(glideRequestManager)
-        val adapter = PagedGalleryAdapter(glideRequestManager)
+        val adapter = GalleryAdapter(glideRequestManager)
         recyclerView.adapter = adapter
         recyclerView.addItemDecoration(GallerySpacingItemDecoration(resources))
         lifecycleScope.launch {
             viewModel.pagedGallery().collectLatest { adapter.submitData(it) }
         }
-
-//        viewModel.gallery.observe(this, DataObserver<UiGallery> { gallery ->
-//            adapter.submitList(gallery)
-//        })
 
         viewModel.events.observe(this, EventObserver { command ->
             when (command) {
@@ -63,39 +53,5 @@ class GalleryActivity : AppCompatActivity() {
         val paintingIntent = paintingIntent(command.artistId, command.paintingId, command.imageUrl)
         val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, Pair(command.view, getString(R.string.shared_element_painting)))
         startActivity(paintingIntent, options.toBundle())
-    }
-}
-
-private class PagedGalleryAdapter(private val glideRequestManager: RequestManager)
-    : PagingDataAdapter<UiPainting, PagedGalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
-        return PaintingViewHolder(glideRequestManager, view)
-    }
-
-    override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) {
-        // the item might be null while loading - TODO: placeholders
-        getItem(position)?.let { viewHolder.bind(it) }
-    }
-
-    object PaintingDiffer : DiffUtil.ItemCallback<UiPainting>() {
-        override fun areItemsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem.id == newItem.id
-        override fun areContentsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem == newItem
-    }
-
-    internal class PaintingViewHolder(
-            private val glideRequestManager: RequestManager,
-            view: View
-    ) : RecyclerView.ViewHolder(view) {
-
-        fun bind(item: UiPainting) {
-            itemView.setOnClickListener { item.onClickPainting(itemView.imageView) }
-            itemView.artistTextView.text = item.artistName
-            itemView.artistTextView.setOnClickListener { item.onClickArtist() }
-            glideRequestManager
-                    .load(item.imageUrl)
-                    .into(itemView.imageView)
-        }
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryActivity.kt
@@ -1,16 +1,24 @@
 package com.ataulm.artcollector.gallery.ui
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.util.Pair
+import androidx.lifecycle.lifecycleScope
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager.widget.PagerAdapter
 import com.ataulm.artcollector.*
 import com.ataulm.artcollector.gallery.injectDependencies
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.activity_gallery.*
 import kotlinx.android.synthetic.main.itemview_painting.view.*
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class GalleryActivity : AppCompatActivity() {
@@ -26,13 +34,17 @@ class GalleryActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_gallery)
 
-        val adapter = GalleryAdapter(glideRequestManager)
+//        val adapter = GalleryAdapter(glideRequestManager)
+        val adapter = PagedGalleryAdapter(glideRequestManager)
         recyclerView.adapter = adapter
         recyclerView.addItemDecoration(GallerySpacingItemDecoration(resources))
+        lifecycleScope.launch {
+            viewModel.pagedGallery().collectLatest { adapter.submitData(it) }
+        }
 
-        viewModel.gallery.observe(this, DataObserver<UiGallery> { gallery ->
-            adapter.submitList(gallery)
-        })
+//        viewModel.gallery.observe(this, DataObserver<UiGallery> { gallery ->
+//            adapter.submitList(gallery)
+//        })
 
         viewModel.events.observe(this, EventObserver { command ->
             when (command) {
@@ -48,14 +60,42 @@ class GalleryActivity : AppCompatActivity() {
     }
 
     private fun navigateToPainting(command: NavigateToPainting) {
-        val (painting, adapterPosition) = command.painting to command.adapterPosition
-        val paintingIntent = paintingIntent(painting.artistId, painting.id, painting.imageUrl)
-        val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, recyclerView.sharedElements(adapterPosition))
+        val paintingIntent = paintingIntent(command.artistId, command.paintingId, command.imageUrl)
+        val options = ActivityOptionsCompat.makeSceneTransitionAnimation(this, Pair(command.view, getString(R.string.shared_element_painting)))
         startActivity(paintingIntent, options.toBundle())
     }
+}
 
-    private fun RecyclerView.sharedElements(adapterPosition: Int): Pair<View, String> {
-        val itemView = layoutManager?.findViewByPosition(adapterPosition)!!
-        return Pair(itemView.imageView as View, getString(R.string.shared_element_painting))
+private class PagedGalleryAdapter(private val glideRequestManager: RequestManager)
+    : PagingDataAdapter<UiPainting, PagedGalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
+        return PaintingViewHolder(glideRequestManager, view)
+    }
+
+    override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) {
+        // the item might be null while loading - TODO: placeholders
+        getItem(position)?.let { viewHolder.bind(it) }
+    }
+
+    object PaintingDiffer : DiffUtil.ItemCallback<UiPainting>() {
+        override fun areItemsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem == newItem
+    }
+
+    internal class PaintingViewHolder(
+            private val glideRequestManager: RequestManager,
+            view: View
+    ) : RecyclerView.ViewHolder(view) {
+
+        fun bind(item: UiPainting) {
+            itemView.setOnClickListener { item.onClickPainting(itemView.imageView) }
+            itemView.artistTextView.text = item.artistName
+            itemView.artistTextView.setOnClickListener { item.onClickArtist() }
+            glideRequestManager
+                    .load(item.imageUrl)
+                    .into(itemView.imageView)
+        }
     }
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
@@ -3,6 +3,7 @@ package com.ataulm.artcollector.gallery.ui
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -10,16 +11,18 @@ import com.ataulm.artcollector.R
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.itemview_painting.view.*
 
-internal class GalleryAdapter constructor(
-        private val glideRequestManager: RequestManager
-) : ListAdapter<UiPainting, GalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
+internal class GalleryAdapter(private val glideRequestManager: RequestManager)
+    : PagingDataAdapter<UiPainting, GalleryAdapter.PaintingViewHolder>(PaintingDiffer) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_painting, parent, false)
         return PaintingViewHolder(glideRequestManager, view)
     }
 
-    override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
+    override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) {
+        // the item might be null while loading - TODO: placeholders
+        getItem(position)?.let { viewHolder.bind(it) }
+    }
 
     object PaintingDiffer : DiffUtil.ItemCallback<UiPainting>() {
         override fun areItemsTheSame(oldItem: UiPainting, newItem: UiPainting) = oldItem.id == newItem.id

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryAdapter.kt
@@ -32,9 +32,9 @@ internal class GalleryAdapter constructor(
     ) : RecyclerView.ViewHolder(view) {
 
         fun bind(item: UiPainting) {
-            itemView.setOnClickListener { item.onClickPainting(adapterPosition) }
+            itemView.setOnClickListener { item.onClickPainting(itemView.imageView) }
             itemView.artistTextView.text = item.artistName
-            itemView.artistTextView.setOnClickListener { item.onClickArtist(adapterPosition) }
+            itemView.artistTextView.setOnClickListener { item.onClickArtist() }
             glideRequestManager
                     .load(item.imageUrl)
                     .into(itemView.imageView)

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModel.kt
@@ -8,20 +8,15 @@ import androidx.paging.*
 import com.ataulm.artcollector.Event
 import com.ataulm.artcollector.Painting
 import com.ataulm.artcollector.gallery.domain.GetGalleryUseCase
-import com.ataulm.artcollector.gallery.domain.GetPagedGalleryUseCase
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 internal class GalleryViewModel @Inject constructor(
-        private val getGallery: GetGalleryUseCase,
-        private val getPagedGallery: GetPagedGalleryUseCase
+        private val getGallery: GetGalleryUseCase
 ) : ViewModel() {
-
-    private val _gallery = MutableLiveData<UiGallery>()
-    val gallery: LiveData<UiGallery> = _gallery
 
     private val _events = MutableLiveData<Event<NavigateCommand>>()
     val events: LiveData<Event<NavigateCommand>>
@@ -30,17 +25,8 @@ internal class GalleryViewModel @Inject constructor(
     private val parentJob = Job()
     private val coroutineScope = CoroutineScope(parentJob)
 
-    init {
-//        coroutineScope.launch(Dispatchers.IO) {
-//            val gallery = getGallery()
-//            val paintingUis = gallery.map { it.toUiModel() }
-//            val uiGallery = UiGallery(paintingUis)
-//            withContext(Dispatchers.Main) { _gallery.value = uiGallery }
-//        }
-    }
-
     fun pagedGallery(): Flow<PagingData<UiPainting>> {
-        val pagingSource = getPagedGallery()
+        val pagingSource = getGallery()
         val pager = Pager(config = PagingConfig(pageSize = 9)) { pagingSource }
         return pager.flow.map { paintingPagingData: PagingData<Painting> ->
             paintingPagingData.map { it.toUiModel() }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModelFactory.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModelFactory.kt
@@ -3,15 +3,13 @@ package com.ataulm.artcollector.gallery.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.ataulm.artcollector.gallery.domain.GetGalleryUseCase
-import com.ataulm.artcollector.gallery.domain.GetPagedGalleryUseCase
 import javax.inject.Inject
 
 internal class GalleryViewModelFactory @Inject constructor(
-        private val getGalleryUseCase: GetGalleryUseCase,
-        private val getPagedGalleryUseCase: GetPagedGalleryUseCase
+        private val getGalleryUseCase: GetGalleryUseCase
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>) =
-            GalleryViewModel(getGalleryUseCase, getPagedGalleryUseCase) as T
+            GalleryViewModel(getGalleryUseCase) as T
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModelFactory.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/GalleryViewModelFactory.kt
@@ -3,13 +3,15 @@ package com.ataulm.artcollector.gallery.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.ataulm.artcollector.gallery.domain.GetGalleryUseCase
+import com.ataulm.artcollector.gallery.domain.GetPagedGalleryUseCase
 import javax.inject.Inject
 
 internal class GalleryViewModelFactory @Inject constructor(
-        private val galleryUseCase: GetGalleryUseCase
+        private val getGalleryUseCase: GetGalleryUseCase,
+        private val getPagedGalleryUseCase: GetPagedGalleryUseCase
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>) =
-            GalleryViewModel(galleryUseCase) as T
+            GalleryViewModel(getGalleryUseCase, getPagedGalleryUseCase) as T
 }

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiGallery.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiGallery.kt
@@ -1,3 +1,0 @@
-package com.ataulm.artcollector.gallery.ui
-
-internal class UiGallery(collection: Collection<UiPainting>) : ArrayList<UiPainting>(collection)

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
@@ -1,5 +1,7 @@
 package com.ataulm.artcollector.gallery.ui
 
+import android.view.View
+
 internal data class UiPainting(
         val id: String,
         val title: String,
@@ -7,9 +9,8 @@ internal data class UiPainting(
         val artistId: String,
         val artistName: String,
         /**
-         * The `Int` parameter is the view adapter position. This is needed to get a reference
-         * to the item view for the shared element transition. Same with [onClickArtist].
+         * The `view` parameter is used for the shared element transition.
          */
-        val onClickPainting: (Int) -> Unit,
-        val onClickArtist: (Int) -> Unit
+        val onClickPainting: (View) -> Unit,
+        val onClickArtist: () -> Unit
 )

--- a/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
+++ b/app/src/main/java/com/ataulm/artcollector/gallery/ui/UiPainting.kt
@@ -8,9 +8,6 @@ internal data class UiPainting(
         val imageUrl: String,
         val artistId: String,
         val artistName: String,
-        /**
-         * The `view` parameter is used for the shared element transition.
-         */
         val onClickPainting: (View) -> Unit,
         val onClickArtist: () -> Unit
 )

--- a/artist/build.gradle
+++ b/artist/build.gradle
@@ -4,6 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     compileSdkVersion versions.androidSdk.compile
     defaultConfig {
         minSdkVersion versions.androidSdk.min

--- a/artist/src/main/java/com/ataulm/artcollector/artist/data/AndroidArtistRepository.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/data/AndroidArtistRepository.kt
@@ -16,20 +16,20 @@ internal class AndroidArtistRepository @Inject constructor(
         private val artistId: ArtistId
 ) : ArtistRepository {
 
-    override suspend fun artist(): com.ataulm.artcollector.Artist {
+    override suspend fun artist(): Artist {
         val qValue = "personid:${artistId.value}"
-        return harvardArtMuseumApi.artist(qValue).await().records.first().toArtist()
+        return harvardArtMuseumApi.artist(qValue).records.first().toArtist()
     }
 
-    override suspend fun artistGallery(): com.ataulm.artcollector.Gallery {
-        val paintings = harvardArtMuseumApi.artistGallery(artistId.value).await().records
+    override suspend fun artistGallery(): Gallery {
+        val paintings = harvardArtMuseumApi.artistGallery(artistId.value).records
                 .map { it.toPainting() }
-        return com.ataulm.artcollector.Gallery(paintings)
+        return Gallery(paintings)
     }
 
-    private fun ApiObjectRecord.toPainting(): com.ataulm.artcollector.Painting {
+    private fun ApiObjectRecord.toPainting(): Painting {
         val apiPerson = people.first()
-        return com.ataulm.artcollector.Painting(
+        return Painting(
                 id.toString(),
                 title,
                 url,
@@ -40,6 +40,6 @@ internal class AndroidArtistRepository @Inject constructor(
         )
     }
 
-    private fun ApiPerson.toArtist() = com.ataulm.artcollector.Artist(personId.toString(), name)
-    private fun ApiPersonRecord.toArtist() = com.ataulm.artcollector.Artist(personId.toString(), displayName)
+    private fun ApiPerson.toArtist() = Artist(personId.toString(), name)
+    private fun ApiPersonRecord.toArtist() = Artist(personId.toString(), displayName)
 }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/data/AndroidArtistRepository.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/data/AndroidArtistRepository.kt
@@ -6,9 +6,9 @@ import com.ataulm.artcollector.ApiPersonRecord
 import com.ataulm.artcollector.HarvardArtMuseumApi
 import com.ataulm.artcollector.artist.domain.ArtistId
 import com.ataulm.artcollector.artist.domain.ArtistRepository
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Gallery
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.Gallery
+import com.ataulm.artcollector.Painting
 import javax.inject.Inject
 
 internal class AndroidArtistRepository @Inject constructor(
@@ -16,20 +16,20 @@ internal class AndroidArtistRepository @Inject constructor(
         private val artistId: ArtistId
 ) : ArtistRepository {
 
-    override suspend fun artist(): Artist {
+    override suspend fun artist(): com.ataulm.artcollector.Artist {
         val qValue = "personid:${artistId.value}"
         return harvardArtMuseumApi.artist(qValue).await().records.first().toArtist()
     }
 
-    override suspend fun artistGallery(): Gallery {
+    override suspend fun artistGallery(): com.ataulm.artcollector.Gallery {
         val paintings = harvardArtMuseumApi.artistGallery(artistId.value).await().records
                 .map { it.toPainting() }
-        return Gallery(paintings)
+        return com.ataulm.artcollector.Gallery(paintings)
     }
 
-    private fun ApiObjectRecord.toPainting(): Painting {
+    private fun ApiObjectRecord.toPainting(): com.ataulm.artcollector.Painting {
         val apiPerson = people.first()
-        return Painting(
+        return com.ataulm.artcollector.Painting(
                 id.toString(),
                 title,
                 url,
@@ -40,6 +40,6 @@ internal class AndroidArtistRepository @Inject constructor(
         )
     }
 
-    private fun ApiPerson.toArtist() = Artist(personId.toString(), name)
-    private fun ApiPersonRecord.toArtist() = Artist(personId.toString(), displayName)
+    private fun ApiPerson.toArtist() = com.ataulm.artcollector.Artist(personId.toString(), name)
+    private fun ApiPersonRecord.toArtist() = com.ataulm.artcollector.Artist(personId.toString(), displayName)
 }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
@@ -5,7 +5,7 @@ import com.ataulm.artcollector.Gallery
 
 internal interface ArtistRepository {
 
-    suspend fun artist(): com.ataulm.artcollector.Artist
+    suspend fun artist(): Artist
 
-    suspend fun artistGallery(): com.ataulm.artcollector.Gallery
+    suspend fun artistGallery(): Gallery
 }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/domain/ArtistRepository.kt
@@ -1,11 +1,11 @@
 package com.ataulm.artcollector.artist.domain
 
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Gallery
+import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.Gallery
 
 internal interface ArtistRepository {
 
-    suspend fun artist(): Artist
+    suspend fun artist(): com.ataulm.artcollector.Artist
 
-    suspend fun artistGallery(): Gallery
+    suspend fun artistGallery(): com.ataulm.artcollector.Gallery
 }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistAdapter.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistAdapter.kt
@@ -6,15 +6,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.ataulm.artcollector.artist.R
 import com.ataulm.artcollector.Painting
+import com.ataulm.artcollector.artist.R
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.itemview_artist_painting.view.*
 
 internal class ArtistAdapter constructor(
         private val glideRequestManager: RequestManager,
         private val onClick: (Int) -> Unit
-) : ListAdapter<com.ataulm.artcollector.Painting, ArtistAdapter.PaintingViewHolder>(PaintingDiffer) {
+) : ListAdapter<Painting, ArtistAdapter.PaintingViewHolder>(PaintingDiffer) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_artist_painting, parent, false)
@@ -23,9 +23,9 @@ internal class ArtistAdapter constructor(
 
     override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
 
-    object PaintingDiffer : DiffUtil.ItemCallback<com.ataulm.artcollector.Painting>() {
-        override fun areItemsTheSame(oldItem: com.ataulm.artcollector.Painting, newItem: com.ataulm.artcollector.Painting) = oldItem.id == newItem.id
-        override fun areContentsTheSame(oldItem: com.ataulm.artcollector.Painting, newItem: com.ataulm.artcollector.Painting) = oldItem == newItem
+    object PaintingDiffer : DiffUtil.ItemCallback<Painting>() {
+        override fun areItemsTheSame(oldItem: Painting, newItem: Painting) = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Painting, newItem: Painting) = oldItem == newItem
     }
 
     internal class PaintingViewHolder(
@@ -34,7 +34,7 @@ internal class ArtistAdapter constructor(
             view: View
     ) : RecyclerView.ViewHolder(view) {
 
-        fun bind(item: com.ataulm.artcollector.Painting) {
+        fun bind(item: Painting) {
             itemView.setOnClickListener { onClick(adapterPosition) }
             glideRequestManager.load(item.imageUrl).into(itemView.imageView)
         }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistAdapter.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistAdapter.kt
@@ -7,14 +7,14 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ataulm.artcollector.artist.R
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Painting
 import com.bumptech.glide.RequestManager
 import kotlinx.android.synthetic.main.itemview_artist_painting.view.*
 
 internal class ArtistAdapter constructor(
         private val glideRequestManager: RequestManager,
         private val onClick: (Int) -> Unit
-) : ListAdapter<Painting, ArtistAdapter.PaintingViewHolder>(PaintingDiffer) {
+) : ListAdapter<com.ataulm.artcollector.Painting, ArtistAdapter.PaintingViewHolder>(PaintingDiffer) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PaintingViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.itemview_artist_painting, parent, false)
@@ -23,9 +23,9 @@ internal class ArtistAdapter constructor(
 
     override fun onBindViewHolder(viewHolder: PaintingViewHolder, position: Int) = viewHolder.bind(getItem(position))
 
-    object PaintingDiffer : DiffUtil.ItemCallback<Painting>() {
-        override fun areItemsTheSame(oldItem: Painting, newItem: Painting) = oldItem.id == newItem.id
-        override fun areContentsTheSame(oldItem: Painting, newItem: Painting) = oldItem == newItem
+    object PaintingDiffer : DiffUtil.ItemCallback<com.ataulm.artcollector.Painting>() {
+        override fun areItemsTheSame(oldItem: com.ataulm.artcollector.Painting, newItem: com.ataulm.artcollector.Painting) = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: com.ataulm.artcollector.Painting, newItem: com.ataulm.artcollector.Painting) = oldItem == newItem
     }
 
     internal class PaintingViewHolder(
@@ -34,7 +34,7 @@ internal class ArtistAdapter constructor(
             view: View
     ) : RecyclerView.ViewHolder(view) {
 
-        fun bind(item: Painting) {
+        fun bind(item: com.ataulm.artcollector.Painting) {
             itemView.setOnClickListener { onClick(adapterPosition) }
             glideRequestManager.load(item.imageUrl).into(itemView.imageView)
         }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModel.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.ViewModel
 import com.ataulm.artcollector.Event
 import com.ataulm.artcollector.artist.domain.GetArtistGalleryUseCase
 import com.ataulm.artcollector.artist.domain.GetArtistUseCase
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Gallery
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.Gallery
+import com.ataulm.artcollector.Painting
 import kotlinx.coroutines.*
 import javax.inject.Inject
 
@@ -18,8 +18,8 @@ internal class ArtistViewModel @Inject constructor(
         private val getArtistGallery: GetArtistGalleryUseCase
 ) : ViewModel() {
 
-    private val _artist = MutableLiveData<Artist>()
-    private val _gallery = MutableLiveData<Gallery>()
+    private val _artist = MutableLiveData<com.ataulm.artcollector.Artist>()
+    private val _gallery = MutableLiveData<com.ataulm.artcollector.Gallery>()
 
     private val _artistGallery = ArtistGalleryMediatorLiveData()
     val artistGallery: LiveData<ArtistGallery> = _artistGallery
@@ -57,21 +57,21 @@ internal class ArtistViewModel @Inject constructor(
     }
 }
 
-internal data class NavigateToPainting(val painting: Painting, val adapterPosition: Int)
+internal data class NavigateToPainting(val painting: com.ataulm.artcollector.Painting, val adapterPosition: Int)
 
-internal data class ArtistGallery(val artist: Artist, val gallery: Gallery)
+internal data class ArtistGallery(val artist: com.ataulm.artcollector.Artist, val gallery: com.ataulm.artcollector.Gallery)
 
 private class ArtistGalleryMediatorLiveData : MediatorLiveData<ArtistGallery>() {
 
-    private var artist: Artist? = null
-    private var gallery: Gallery? = null
+    private var artist: com.ataulm.artcollector.Artist? = null
+    private var gallery: com.ataulm.artcollector.Gallery? = null
 
-    fun update(artist: Artist) {
+    fun update(artist: com.ataulm.artcollector.Artist) {
         this.artist = artist
         onUpdate()
     }
 
-    fun update(gallery: Gallery) {
+    fun update(gallery: com.ataulm.artcollector.Gallery) {
         this.gallery = gallery
         onUpdate()
     }

--- a/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModel.kt
+++ b/artist/src/main/java/com/ataulm/artcollector/artist/ui/ArtistViewModel.kt
@@ -18,8 +18,8 @@ internal class ArtistViewModel @Inject constructor(
         private val getArtistGallery: GetArtistGalleryUseCase
 ) : ViewModel() {
 
-    private val _artist = MutableLiveData<com.ataulm.artcollector.Artist>()
-    private val _gallery = MutableLiveData<com.ataulm.artcollector.Gallery>()
+    private val _artist = MutableLiveData<Artist>()
+    private val _gallery = MutableLiveData<Gallery>()
 
     private val _artistGallery = ArtistGalleryMediatorLiveData()
     val artistGallery: LiveData<ArtistGallery> = _artistGallery
@@ -57,21 +57,21 @@ internal class ArtistViewModel @Inject constructor(
     }
 }
 
-internal data class NavigateToPainting(val painting: com.ataulm.artcollector.Painting, val adapterPosition: Int)
+internal data class NavigateToPainting(val painting: Painting, val adapterPosition: Int)
 
-internal data class ArtistGallery(val artist: com.ataulm.artcollector.Artist, val gallery: com.ataulm.artcollector.Gallery)
+internal data class ArtistGallery(val artist: Artist, val gallery: Gallery)
 
 private class ArtistGalleryMediatorLiveData : MediatorLiveData<ArtistGallery>() {
 
-    private var artist: com.ataulm.artcollector.Artist? = null
-    private var gallery: com.ataulm.artcollector.Gallery? = null
+    private var artist: Artist? = null
+    private var gallery: Gallery? = null
 
-    fun update(artist: com.ataulm.artcollector.Artist) {
+    fun update(artist: Artist) {
         this.artist = artist
         onUpdate()
     }
 
-    fun update(gallery: com.ataulm.artcollector.Gallery) {
+    fun update(gallery: Gallery) {
         this.gallery = gallery
         onUpdate()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://dl.bintray.com/kotlin/kotlin-eap/'
-        }
     }
     dependencies {
         classpath libraries.build.androidGradle
@@ -18,7 +15,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap/' }
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         maven { url "https://jitpack.io" }
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,8 +7,8 @@ ext {
             ],
             chuck           : '1.1.0',
             dagger          : '2.16',
-            kotlin          : '1.3.10',
-            kotlinCoroutines: '1.0.0-RC1',
+            kotlin          : '1.3.71',
+            kotlinCoroutines: '1.3.8',
             moshi           : '1.7.0'
     ]
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,8 @@ ext {
             dagger          : '2.16',
             kotlin          : '1.3.71',
             kotlinCoroutines: '1.3.8',
-            moshi           : '1.7.0'
+            moshi           : '1.7.0',
+            paging          : '3.0.0-alpha03'
     ]
 
     libraries = [
@@ -24,6 +25,8 @@ ext {
             androidxLegacySupportV13   : 'androidx.legacy:legacy-support-v13:1.0.0',
             androidxLifecycleExtensions: 'androidx.lifecycle:lifecycle-extensions:2.0.0',
             androidxMaterial           : 'com.google.android.material:material:1.1.0-alpha01',
+            androidxPagingCommon       : "androidx.paging:paging-common:${versions.paging}",
+            androidxPagingRuntime      : "androidx.paging:paging-runtime:${versions.paging}",
             androidxRecyclerView       : 'androidx.recyclerview:recyclerview:1.0.0',
             androidxTestRules          : 'androidx.test:rules:1.1.0',
             androidxTestRunner         : 'androidx.test:runner:1.1.0',
@@ -43,8 +46,7 @@ ext {
             moshi                      : "com.squareup.moshi:moshi:${versions.moshi}",
             moshiKotlinCodegen         : "com.squareup.moshi:moshi-kotlin-codegen:${versions.moshi}",
             photoView                  : 'com.github.chrisbanes:PhotoView:2.0.0',
-            retrofit                   : 'com.squareup.retrofit2:retrofit:2.4.0',
-            retrofitKotlinCoroutines   : 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2',
+            retrofit                   : 'com.squareup.retrofit2:retrofit:2.8.1',
             retrofitMoshi              : 'com.squareup.retrofit2:converter-moshi:2.4.0'
     ]
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,10 +4,11 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_7
-    targetCompatibility = JavaVersion.VERSION_1_7
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {
     implementation libraries.kotlinStdLib
+    api libraries.androidxPagingCommon
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java-library'
+    id 'kotlin'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_7
+}
+
+dependencies {
+    implementation libraries.kotlinStdLib
+}

--- a/domain/src/main/java/com/ataulm/artcollector/Artist.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/Artist.kt
@@ -1,3 +1,3 @@
-package com.ataulm.artcollector.domain
+package com.ataulm.artcollector
 
 data class Artist(val id: String, val name: String)

--- a/domain/src/main/java/com/ataulm/artcollector/Gallery.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/Gallery.kt
@@ -1,3 +1,3 @@
-package com.ataulm.artcollector.domain
+package com.ataulm.artcollector
 
 class Gallery(collection: Collection<Painting>) : ArrayList<Painting>(collection)

--- a/domain/src/main/java/com/ataulm/artcollector/Painting.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/Painting.kt
@@ -1,4 +1,4 @@
-package com.ataulm.artcollector.domain
+package com.ataulm.artcollector
 
 data class Painting(
         val id: String,

--- a/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
@@ -1,0 +1,8 @@
+package com.ataulm.artcollector.datanotdomain
+
+import com.ataulm.artcollector.Gallery
+
+interface GalleryRepository {
+
+    suspend fun gallery(): Gallery
+}

--- a/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
@@ -1,12 +1,9 @@
 package com.ataulm.artcollector.datanotdomain
 
 import androidx.paging.PagingSource
-import com.ataulm.artcollector.Gallery
 import com.ataulm.artcollector.Painting
 
 interface GalleryRepository {
 
-    suspend fun gallery(): Gallery
-
-    fun pagedGallery(): PagingSource<Int, Painting>
+    fun gallery(): PagingSource<Int, Painting>
 }

--- a/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
+++ b/domain/src/main/java/com/ataulm/artcollector/datanotdomain/GalleryRepository.kt
@@ -1,8 +1,12 @@
 package com.ataulm.artcollector.datanotdomain
 
+import androidx.paging.PagingSource
 import com.ataulm.artcollector.Gallery
+import com.ataulm.artcollector.Painting
 
 interface GalleryRepository {
 
     suspend fun gallery(): Gallery
+
+    fun pagedGallery(): PagingSource<Int, Painting>
 }

--- a/painting/build.gradle
+++ b/painting/build.gradle
@@ -4,6 +4,10 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     compileSdkVersion versions.androidSdk.compile
     defaultConfig {
         minSdkVersion versions.androidSdk.min

--- a/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
@@ -2,8 +2,8 @@ package com.ataulm.artcollector.painting.data
 
 import com.ataulm.artcollector.ApiObjectRecord
 import com.ataulm.artcollector.HarvardArtMuseumApi
-import com.ataulm.artcollector.domain.Artist
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Artist
+import com.ataulm.artcollector.Painting
 import com.ataulm.artcollector.painting.domain.PaintingId
 import com.ataulm.artcollector.painting.domain.PaintingRepository
 import javax.inject.Inject
@@ -13,20 +13,20 @@ internal class AndroidPaintingRepository @Inject constructor(
         private val paintingId: PaintingId
 ) : PaintingRepository {
 
-    override suspend fun painting(): Painting {
+    override suspend fun painting(): com.ataulm.artcollector.Painting {
         return harvardArtMuseumApi.painting(paintingId.value).await().toPainting()
     }
 
-    private fun ApiObjectRecord.toPainting(): Painting {
+    private fun ApiObjectRecord.toPainting(): com.ataulm.artcollector.Painting {
         val apiPerson = people.first()
-        return Painting(
+        return com.ataulm.artcollector.Painting(
                 id.toString(),
                 title,
                 url,
                 description,
                 creditLine,
                 primaryImageUrl,
-                Artist(apiPerson.personId.toString(), apiPerson.name)
+                com.ataulm.artcollector.Artist(apiPerson.personId.toString(), apiPerson.name)
         )
     }
 }

--- a/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
@@ -13,13 +13,13 @@ internal class AndroidPaintingRepository @Inject constructor(
         private val paintingId: PaintingId
 ) : PaintingRepository {
 
-    override suspend fun painting(): com.ataulm.artcollector.Painting {
-        return harvardArtMuseumApi.painting(paintingId.value).await().toPainting()
+    override suspend fun painting(): Painting {
+        return harvardArtMuseumApi.painting(paintingId.value).toPainting()
     }
 
-    private fun ApiObjectRecord.toPainting(): com.ataulm.artcollector.Painting {
+    private fun ApiObjectRecord.toPainting(): Painting {
         val apiPerson = people.first()
-        return com.ataulm.artcollector.Painting(
+        return Painting(
                 id.toString(),
                 title,
                 url,

--- a/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/data/AndroidPaintingRepository.kt
@@ -26,7 +26,7 @@ internal class AndroidPaintingRepository @Inject constructor(
                 description,
                 creditLine,
                 primaryImageUrl,
-                com.ataulm.artcollector.Artist(apiPerson.personId.toString(), apiPerson.name)
+                Artist(apiPerson.personId.toString(), apiPerson.name)
         )
     }
 }

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
@@ -4,5 +4,5 @@ import com.ataulm.artcollector.Painting
 
 internal interface PaintingRepository {
 
-    suspend fun painting(): com.ataulm.artcollector.Painting
+    suspend fun painting(): Painting
 }

--- a/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/domain/PaintingRepository.kt
@@ -1,8 +1,8 @@
 package com.ataulm.artcollector.painting.domain
 
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Painting
 
 internal interface PaintingRepository {
 
-    suspend fun painting(): Painting
+    suspend fun painting(): com.ataulm.artcollector.Painting
 }

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.ataulm.artcollector.DataObserver
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Painting
 import com.ataulm.artcollector.imageUrl
 import com.ataulm.artcollector.painting.R
 import com.ataulm.artcollector.painting.domain.PaintingId
@@ -38,7 +38,7 @@ class PaintingActivity : AppCompatActivity() {
         postponeEnterTransition()
 
         intent.loadImageIfAvailable()
-        viewModel.painting.observe(this, DataObserver<Painting> { painting ->
+        viewModel.painting.observe(this, DataObserver<com.ataulm.artcollector.Painting> { painting ->
             title = painting.title
             titleArtistTextView.text = getString(R.string.painting_title_artist, painting.title, painting.artist.name)
             creditLineTextView.text = painting.creditLine?.let { getString(R.string.painting_credit, it) }
@@ -65,7 +65,7 @@ class PaintingActivity : AppCompatActivity() {
         }
     }
 
-    private fun Painting.loadImageIfDifferent() {
+    private fun com.ataulm.artcollector.Painting.loadImageIfDifferent() {
         if (imageUrl != intent.imageUrl()) {
             glideRequestManager.clear(imageView)
             glideRequestManager.load(imageUrl)

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingActivity.kt
@@ -38,7 +38,7 @@ class PaintingActivity : AppCompatActivity() {
         postponeEnterTransition()
 
         intent.loadImageIfAvailable()
-        viewModel.painting.observe(this, DataObserver<com.ataulm.artcollector.Painting> { painting ->
+        viewModel.painting.observe(this, DataObserver<Painting> { painting ->
             title = painting.title
             titleArtistTextView.text = getString(R.string.painting_title_artist, painting.title, painting.artist.name)
             creditLineTextView.text = painting.creditLine?.let { getString(R.string.painting_credit, it) }
@@ -65,7 +65,7 @@ class PaintingActivity : AppCompatActivity() {
         }
     }
 
-    private fun com.ataulm.artcollector.Painting.loadImageIfDifferent() {
+    private fun Painting.loadImageIfDifferent() {
         if (imageUrl != intent.imageUrl()) {
             glideRequestManager.clear(imageView)
             glideRequestManager.load(imageUrl)

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
@@ -12,8 +12,8 @@ internal class PaintingViewModel @Inject constructor(
         private val getPainting: GetPaintingUseCase
 ) : ViewModel() {
 
-    private val _painting = MutableLiveData<com.ataulm.artcollector.Painting>()
-    val painting: LiveData<com.ataulm.artcollector.Painting> = _painting
+    private val _painting = MutableLiveData<Painting>()
+    val painting: LiveData<Painting> = _painting
 
     private val parentJob = Job()
     private val coroutineScope = CoroutineScope(parentJob)

--- a/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
+++ b/painting/src/main/java/com/ataulm/artcollector/painting/ui/PaintingViewModel.kt
@@ -3,7 +3,7 @@ package com.ataulm.artcollector.painting.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.ataulm.artcollector.domain.Painting
+import com.ataulm.artcollector.Painting
 import com.ataulm.artcollector.painting.domain.GetPaintingUseCase
 import kotlinx.coroutines.*
 import javax.inject.Inject
@@ -12,8 +12,8 @@ internal class PaintingViewModel @Inject constructor(
         private val getPainting: GetPaintingUseCase
 ) : ViewModel() {
 
-    private val _painting = MutableLiveData<Painting>()
-    val painting: LiveData<Painting> = _painting
+    private val _painting = MutableLiveData<com.ataulm.artcollector.Painting>()
+    val painting: LiveData<com.ataulm.artcollector.Painting> = _painting
 
     private val parentJob = Job()
     private val coroutineScope = CoroutineScope(parentJob)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 include ':app'
 include ':artist'
+include ':domain'
 include ':painting'


### PR DESCRIPTION
Fixes #26 

Adds the Paging 3 library to the Gallery (initial) screen. Creates a PagingSource that fetches from the network only (no Room/cache).

#### domain module

This PR also extracts a Kotlin-only library called `domain`, since it's relatively common to have non-android modules either for clean arch or multiplatform reasons. 

`paging-common` is highlighted on the docs with the comment "// alternatively - without Android dependencies for tests" but we can also use it in our kotlin-only modules as it's just a jar, not an android library. I was told that there's a couple of android classes referenced in there (meaning it'd break if those classes were loaded somewhere where android isn't on the classpath?) but I haven't found them.

![image](https://user-images.githubusercontent.com/2678555/88951617-253a7b00-d28e-11ea-92be-82afb6c9aebe.png)
 
#### transitions
we have shared element transitions. we were passing the adapter position of the clicked view to get a reference to the view (the transition manager needs a ref to it), but now we just pass the view because `adapterPosition` is deprecated now and there wasn't any need for that indirection.