### PR TITLE
Fix compose compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     apply from: 'dependencies.gradle'
     repositories {
         google()
+        jcenter()
         mavenCentral()
     }
     dependencies {
@@ -14,7 +15,28 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        jcenter()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
         maven { url "https://jitpack.io" }
+    }
+}
+
+subprojects {
+    repositories {
+        google()
+        jcenter()
+        mavenCentral()
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            jvmTarget = "1.8"
+            freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
+            freeCompilerArgs += '-Xallow-jvm-ir-dependencies'
+            freeCompilerArgs += [
+                    '-P',
+                    'plugin:androidx.compose.compiler.plugins.kotlin:intrinsicRemember=true'
+            ]
+        }
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
             ],
             chuck           : '1.1.0',
             dagger          : '2.16',
-            kotlin          : '1.4.30',
+            kotlin          : '1.4.21-2',
             kotlinCompose   : '1.0.0-alpha11',
             kotlinCoroutines: '1.4.2',
             moshi           : '1.11.0',
@@ -19,7 +19,7 @@ ext {
                     androidGradle: 'com.android.tools.build:gradle:7.0.0-alpha05',
                     kotlinGradle : "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
             ],
-            androidxAppCompat          : 'androidx.appcompat:appcompat:1.0.2',
+            androidxAppCompat          : 'androidx.appcompat:appcompat:1.2.0',
             androidxConstraintLayout   : 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2',
             androidxEspressoCore       : 'androidx.test.espresso:espresso-core:3.1.0',
             androidxLegacySupportV13   : 'androidx.legacy:legacy-support-v13:1.0.0',


### PR DESCRIPTION
I'm not sure if you were seeing the same issues as me from your side, but this wasn't building for me unless I added jcenter. Other than that:

- Updated `appcompat` to a version that works with compose
- Downgraded kotlin to work with Compose (I don't think compose has been built against 1.4.30 yet)
- add a subprojects declaration for compose / kotlin properties (from the [compose samples](https://github.com/android/compose-samples/blob/main/Crane/build.gradle#L60))

